### PR TITLE
Add basic analytics and error reporting

### DIFF
--- a/analytics/analytics.php
+++ b/analytics/analytics.php
@@ -5,6 +5,7 @@ namespace WPCOMVIP\ContentApi;
 defined( 'ABSPATH' ) || die();
 
 define( 'WPCOMVIP__CONTENT_API__STAT_NAME__USAGE', 'vip-test-content-api-usage' );
+define( 'WPCOMVIP__CONTENT_API__STAT_NAME__ERROR', 'vip-test-content-api-error' );
 
 class Analytics {
 	private static $analytics_to_send = [];
@@ -16,6 +17,15 @@ class Analytics {
 	public static function record_usage() {
 		if ( defined( 'FILES_CLIENT_SITE_ID' ) ) {
 			self::$analytics_to_send[ WPCOMVIP__CONTENT_API__STAT_NAME__USAGE ] = constant( 'FILES_CLIENT_SITE_ID' );
+		}
+	}
+
+	public static function record_error( $error_message ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		trigger_error( sprintf( 'vip-content-api (%s): %s', WPCOMVIP__CONTENT_API__PLUGIN_VERSION, $error_message ), E_USER_WARNING );
+
+		if ( defined( 'FILES_CLIENT_SITE_ID' ) ) {
+			self::$analytics_to_send[ WPCOMVIP__CONTENT_API__STAT_NAME__ERROR ] = constant( 'FILES_CLIENT_SITE_ID' );
 		}
 	}
 
@@ -39,6 +49,5 @@ class Analytics {
 			&& defined( 'WPCOM_SANDBOXED' ) && constant( 'WPCOM_SANDBOXED' ) === false;
 	}
 }
-
 
 Analytics::init();

--- a/analytics/analytics.php
+++ b/analytics/analytics.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace WPCOMVIP\ContentApi;
+
+defined( 'ABSPATH' ) || die();
+
+define( 'WPCOMVIP__CONTENT_API__STAT_NAME__USAGE', 'vip-test-content-api-usage' );
+
+class Analytics {
+	private static $analytics_to_send = [];
+
+	public static function init() {
+		add_action( 'shutdown', [ __CLASS__, 'send_analytics' ] );
+	}
+
+	public static function record_usage() {
+		if ( defined( 'FILES_CLIENT_SITE_ID' ) ) {
+			self::$analytics_to_send[ WPCOMVIP__CONTENT_API__STAT_NAME__USAGE ] = constant( 'FILES_CLIENT_SITE_ID' );
+		}
+	}
+
+	public static function send_analytics() {
+		if ( empty( self::$analytics_to_send ) || ! self::is_analytics_enabled() ) {
+			return;
+		}
+
+		if ( function_exists( 'fastcgi_finish_request' ) ) {
+			// Flush content to client first to prevent blocking REST request
+			fastcgi_finish_request();
+		}
+
+		if ( function_exists( '\Automattic\VIP\Stats\send_pixel' ) ) {
+			\Automattic\VIP\Stats\send_pixel( self::$analytics_to_send );
+		}
+	}
+
+	private static function is_analytics_enabled() {
+		return defined( 'WPCOM_IS_VIP_ENV' ) && constant( 'WPCOM_IS_VIP_ENV' ) === true
+			&& defined( 'WPCOM_SANDBOXED' ) && constant( 'WPCOM_SANDBOXED' ) === false;
+	}
+}
+
+
+Analytics::init();

--- a/analytics/analytics.php
+++ b/analytics/analytics.php
@@ -4,8 +4,8 @@ namespace WPCOMVIP\ContentApi;
 
 defined( 'ABSPATH' ) || die();
 
-define( 'WPCOMVIP__CONTENT_API__STAT_NAME__USAGE', 'vip-test-content-api-usage' );
-define( 'WPCOMVIP__CONTENT_API__STAT_NAME__ERROR', 'vip-test-content-api-error' );
+define( 'WPCOMVIP__CONTENT_API__STAT_NAME__USAGE', 'vip-content-api-usage' );
+define( 'WPCOMVIP__CONTENT_API__STAT_NAME__ERROR', 'vip-content-api-error' );
 
 class Analytics {
 	private static $analytics_to_send = [];

--- a/parser/block-additions/core-image.php
+++ b/parser/block-additions/core-image.php
@@ -12,6 +12,7 @@ class CoreImage {
 	/**
 	 * @param array[string]array $sourced_block
 	 * @param string $block_name
+	 * @param int $post_id
 	 * @param array[string]array $block
 	 *
 	 * @return array[string]array

--- a/parser/content-parser.php
+++ b/parser/content-parser.php
@@ -389,6 +389,6 @@ class ContentParser {
 	}
 
 	protected function is_debug_enabled() {
-		defined( 'VIP_CONTENT_API__PARSE_DEBUG' ) && constant( 'VIP_CONTENT_API__PARSE_DEBUG' ) === true;
+		return defined( 'VIP_CONTENT_API__PARSE_DEBUG' ) && constant( 'VIP_CONTENT_API__PARSE_DEBUG' ) === true;
 	}
 }

--- a/rest/rest-api.php
+++ b/rest/rest-api.php
@@ -32,7 +32,11 @@ class RestApi {
 		$post    = get_post( $post_id );
 
 		$content_parser = new ContentParser();
-		return $content_parser->parse( $post->post_content, $post_id );
+		$parser_results = $content_parser->parse( $post->post_content, $post_id );
+
+		Analytics::record_usage();
+
+		return $parser_results;
 	}
 }
 

--- a/rest/rest-api.php
+++ b/rest/rest-api.php
@@ -2,7 +2,12 @@
 
 namespace WPCOMVIP\ContentApi;
 
+use Exception;
+use WP_Error;
+
 defined( 'ABSPATH' ) || die();
+
+defined( 'WPCOMVIP__CONTENT_API__PARSE_TIME_ERROR_THRESHOLD_MS' ) || define( 'WPCOMVIP__CONTENT_API__PARSE_TIME_ERROR_THRESHOLD_MS', 1000 );
 
 class RestApi {
 	public static function init() {
@@ -31,10 +36,28 @@ class RestApi {
 		$post_id = $params['id'];
 		$post    = get_post( $post_id );
 
-		$content_parser = new ContentParser();
-		$parser_results = $content_parser->parse( $post->post_content, $post_id );
-
 		Analytics::record_usage();
+
+		$parse_time_start = microtime( true );
+
+		try {
+			$content_parser = new ContentParser();
+			$parser_results = $content_parser->parse( $post->post_content, $post_id );
+		} catch ( Exception $exception ) {
+			$error_message = sprintf( 'Error parsing post ID %d: %s', $post_id, $exception );
+			Analytics::record_error( $error_message );
+
+			// Early return to skip parse time check
+			return new WP_Error( 'vip-content-api-parser-error', $exception->getMessage(), [ 'stack_trace' => $exception->getTraceAsString() ] );
+		}
+
+		$parse_time    = microtime( true ) - $parse_time_start;
+		$parse_time_ms = floor( $parse_time * 1000 );
+
+		if ( $parse_time_ms > WPCOMVIP__CONTENT_API__PARSE_TIME_ERROR_THRESHOLD_MS ) {
+			$error_message = sprintf( 'Parse time for post ID %d exceeded threshold: %dms', $post_id, $parse_time_ms );
+			Analytics::record_error( $error_message );
+		}
 
 		return $parser_results;
 	}

--- a/vip-content-api.php
+++ b/vip-content-api.php
@@ -19,12 +19,15 @@ namespace WPCOMVIP\ContentApi;
 
 define( 'WPCOMVIP__CONTENT_API__REST_ROUTE', 'vip-content-api/v1' );
 
-# Composer dependencies
+// Composer dependencies
 require_once __DIR__ . '/vendor/autoload.php';
 
-# /wp-json/ API
+// /wp-json/ API
 require_once __DIR__ . '/rest/rest-api.php';
 
-# Block parsing
+// Block parsing
 require_once __DIR__ . '/parser/content-parser.php';
 require_once __DIR__ . '/parser/block-additions/core-image.php';
+
+// Analytics
+require_once __DIR__ . '/analytics/analytics.php';

--- a/vip-content-api.php
+++ b/vip-content-api.php
@@ -17,6 +17,7 @@
 
 namespace WPCOMVIP\ContentApi;
 
+define( 'WPCOMVIP__CONTENT_API__PLUGIN_VERSION', '0.0.1' );
 define( 'WPCOMVIP__CONTENT_API__REST_ROUTE', 'vip-content-api/v1' );
 
 // Composer dependencies


### PR DESCRIPTION
## Description

Add analytics for usage and error count by site ID. Explicitly log parser exceptions under `vip-content-api` in logs. Additionally, add a 1-second threshold for logging a parser execution time warning.