### PR TITLE
Fix analytics and error logging

### DIFF
--- a/analytics/analytics.php
+++ b/analytics/analytics.php
@@ -34,11 +34,6 @@ class Analytics {
 			return;
 		}
 
-		if ( function_exists( 'fastcgi_finish_request' ) ) {
-			// Flush content to client first to prevent blocking REST request
-			fastcgi_finish_request();
-		}
-
 		if ( function_exists( '\Automattic\VIP\Stats\send_pixel' ) ) {
 			\Automattic\VIP\Stats\send_pixel( self::$analytics_to_send );
 		}

--- a/rest/rest-api.php
+++ b/rest/rest-api.php
@@ -47,8 +47,17 @@ class RestApi {
 			$error_message = sprintf( 'Error parsing post ID %d: %s', $post_id, $exception );
 			Analytics::record_error( $error_message );
 
+			$exception_data     = '';
+			$is_production_site = defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'production' === VIP_GO_APP_ENVIRONMENT;
+
+			if ( ! $is_production_site && true === WP_DEBUG ) {
+				$exception_data = [
+					'stack_trace' => explode( "\n", $exception->getTraceAsString() ),
+				];
+			}
+
 			// Early return to skip parse time check
-			return new WP_Error( 'vip-content-api-parser-error', $exception->getMessage(), [ 'stack_trace' => $exception->getTraceAsString() ] );
+			return new WP_Error( 'vip-content-api-parser-error', $exception->getMessage(), $exception_data );
 		}
 
 		$parse_time    = microtime( true ) - $parse_time_start;


### PR DESCRIPTION
## Description

Adjust analytics and error logging:

- Remove `fastcgi_finish_request()`. This may cause conflicts at a default `shutdown` priority that interfere with other plugin or `vip-go-mu-plugins` hooks. The analytics pixel call increases the API response time by ~`47ms`, which is marginal enough that this risky optimization isn't necessary.
- Previously, all errors for the beta release included a stack trace, including on production. Change this to only disclose stack trace information when running locally.