### PR TITLE
Add 'children' and 'node' attribute sources

### DIFF
--- a/parser/content-parser.php
+++ b/parser/content-parser.php
@@ -182,10 +182,12 @@ class ContentParser {
 			$attribute_value = $this->source_block_raw( $crawler, $block_attribute_definition );
 		} elseif ( 'query' === $attribute_source ) {
 			$attribute_value = $this->source_block_query( $crawler, $block_attribute_definition );
-		} elseif ( 'children' === $attribute_source ) {
-			$attribute_value = $this->source_block_children( $crawler, $block_attribute_definition );
 		} elseif ( 'meta' === $attribute_source ) {
 			$attribute_value = $this->source_block_meta( $block_attribute_definition );
+		} elseif ( 'node' === $attribute_source ) {
+			$attribute_value = $this->source_block_node( $crawler, $block_attribute_definition );
+		} elseif ( 'children' === $attribute_source ) {
+			$attribute_value = $this->source_block_children( $crawler, $block_attribute_definition );
 		}
 
 		if ( null === $attribute_value ) {
@@ -318,62 +320,6 @@ class ContentParser {
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_children( $crawler, $block_attribute_definition ) {
-		// 'children' attribute usage was removed from core in 2018, but not officically deprecated until WordPress 6.1:
-		// https://github.com/WordPress/gutenberg/pull/44265
-		// Parsing code for 'children' can be found in these places:
-		// https://github.com/WordPress/gutenberg/blob/dd0504b/packages/blocks/src/api/parser/get-block-attributes.js#L215-L216
-		// https://github.com/WordPress/gutenberg/blob/dd0504b/packages/blocks/src/api/children.js#L149
-
-		$attribute_values = [];
-		$selector         = $block_attribute_definition['selector'] ?? null;
-
-		if ( null !== $selector ) {
-			$crawler = $crawler->filter( $selector );
-		}
-
-		if ( $crawler->count() === 0 ) {
-			// If the selector doesn't exist, return a default empty array
-			return $attribute_values;
-		}
-
-		$children = $crawler->children();
-
-		if ( $children->count() === 0 ) {
-			// 'children' attributes can be a single element. In this case, return the element value in an array.
-			$attribute_values = [
-				$crawler->html(),
-			];
-		} else {
-			// Use DOMDocument childNodes directly to preserve text nodes. $crawler->children() will return only
-			// element nodes and omit text content.
-			$children_nodes = $crawler->getNode( 0 )->childNodes;
-
-			foreach ( $children_nodes as $node ) {
-				// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- external API calls
-				if ( XML_ELEMENT_NODE === $node->nodeType ) {
-					$attribute_values[] = $node->ownerDocument->saveHtml( $node );
-				} elseif ( XML_TEXT_NODE === $node->nodeType ) {
-					$text = trim( $node->nodeValue );
-
-					// Exclude whitespace-only nodes
-					if ( ! empty( $text ) ) {
-						$attribute_values[] = $text;
-					}
-				}
-				// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			}
-		}
-
-		return $attribute_values;
-	}
-
-	/**
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array $block_attribute_definition
-	 *
-	 * @return string|null
-	 */
 	protected function source_block_tag( $crawler, $block_attribute_definition ) {
 		// The only current usage of the 'tag' attribute is Gutenberg core is the 'core/table' block:
 		// https://github.com/WordPress/gutenberg/blob/796b800/packages/block-library/src/table/block.json#L39
@@ -438,6 +384,121 @@ class ContentParser {
 		} else {
 			return get_post_meta( $post->ID, $meta_key, true );
 		}
+	}
+
+	/**
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler
+	 * @param array $block_attribute_definition
+	 *
+	 * @return string|null
+	 */
+	protected function source_block_children( $crawler, $block_attribute_definition ) {
+		// 'children' attribute usage was removed from core in 2018, but not officically deprecated until WordPress 6.1:
+		// https://github.com/WordPress/gutenberg/pull/44265
+		// Parsing code for 'children' sources can be found here:
+		// https://github.com/WordPress/gutenberg/blob/dd0504b/packages/blocks/src/api/children.js#L149
+
+		$attribute_values = [];
+		$selector         = $block_attribute_definition['selector'] ?? null;
+
+		if ( null !== $selector ) {
+			$crawler = $crawler->filter( $selector );
+		}
+
+		if ( $crawler->count() === 0 ) {
+			// If the selector doesn't exist, return a default empty array
+			return $attribute_values;
+		}
+
+		$children = $crawler->children();
+
+		if ( $children->count() === 0 ) {
+			// 'children' attributes can be a single element. In this case, return the element value in an array.
+			$attribute_values = [
+				$crawler->getNode( 0 )->nodeValue,
+			];
+		} else {
+			// Use DOMDocument childNodes directly to preserve text nodes. $crawler->children() will return only
+			// element nodes and omit text content.
+			$children_nodes = $crawler->getNode( 0 )->childNodes;
+
+			foreach ( $children_nodes as $node ) {
+				$node_value = $this->from_dom_node( $node );
+
+				if ( $node_value ) {
+					$attribute_values[] = $node_value;
+				}
+			}
+		}
+
+		return $attribute_values;
+	}
+
+	/**
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler
+	 * @param array $block_attribute_definition
+	 *
+	 * @return string|null
+	 */
+	protected function source_block_node( $crawler, $block_attribute_definition ) {
+		// 'node' attribute usage was removed from core in 2018, but not officically deprecated until WordPress 6.1:
+		// https://github.com/WordPress/gutenberg/pull/44265
+		// Parsing code for 'node' sources can be found here:
+		// https://github.com/WordPress/gutenberg/blob/dd0504bd34c29b5b2824d82c8d2bb3a8d0f071ec/packages/blocks/src/api/node.js#L125
+
+		$attribute_value = null;
+		$selector        = $block_attribute_definition['selector'] ?? null;
+
+		if ( null !== $selector ) {
+			$crawler = $crawler->filter( $selector );
+		}
+
+		$node       = $crawler->getNode( 0 );
+		$node_value = null;
+
+		if ( $node ) {
+			$node_value = $this->from_dom_node( $node );
+		}
+
+		if ( null !== $node_value ) {
+			$attribute_value = $node_value;
+		}
+
+		return $attribute_value;
+	}
+
+	/**
+	 * Helper function to process markup used by the deprecated 'node' and 'children' sources.
+	 * These sources can return a representation of the DOM tree and bypass the $crawler to access DOMNodes directly.
+	 *
+	 * @param \DOMNode $node
+	 *
+	 * @return array|string|null
+	 */
+	protected function from_dom_node( $node ) {
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- external API calls
+
+		if ( XML_TEXT_NODE === $node->nodeType ) {
+			// For plain text nodes, return the text directly
+			$text = trim( $node->nodeValue );
+
+			// Exclude whitespace-only nodes
+			if ( ! empty( $text ) ) {
+				return $text;
+			}
+		} elseif ( XML_ELEMENT_NODE === $node->nodeType ) {
+			$children = array_map( [ $this, 'from_dom_node' ], iterator_to_array( $node->childNodes ) );
+
+			// For element nodes, recurse and return an array of child nodes
+			return [
+				'type'     => $node->nodeName,
+				'children' => array_filter( $children ),
+			];
+		} else {
+			return null;
+		}
+
+		// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	}
 
 	protected function add_missing_block_warning( $block_name ) {

--- a/parser/content-parser.php
+++ b/parser/content-parser.php
@@ -104,8 +104,10 @@ class ContentParser {
 				}
 			}
 
-			$crawler = new Crawler( $block['innerHTML'] );
-			// Enter the automatically-inserted <body> tag from parser
+			// Specify a manual doctype so that the parser will use the HTML5 parser
+			$crawler = new Crawler( sprintf( '<!doctype html><html><body>%s</body></html>', $block['innerHTML'] ) );
+
+			// Enter the <body> tag for block parsing
 			$crawler = $crawler->filter( 'body' );
 
 			$attribute_value = $this->source_attribute( $crawler, $block_attribute_definition );

--- a/rest/rest-api.php
+++ b/rest/rest-api.php
@@ -8,7 +8,7 @@ use WP_Error;
 
 defined( 'ABSPATH' ) || die();
 
-defined( 'WPCOMVIP__CONTENT_API__PARSE_TIME_ERROR_THRESHOLD_MS' ) || define( 'WPCOMVIP__CONTENT_API__PARSE_TIME_ERROR_THRESHOLD_MS', 1000 );
+defined( 'WPCOMVIP__CONTENT_API__PARSE_TIME_ERROR_THRESHOLD_MS' ) || define( 'WPCOMVIP__CONTENT_API__PARSE_TIME_ERROR_THRESHOLD_MS', 500 );
 
 class RestApi {
 	public static function init() {

--- a/rest/rest-api.php
+++ b/rest/rest-api.php
@@ -2,6 +2,7 @@
 
 namespace WPCOMVIP\ContentApi;
 
+use Error;
 use Exception;
 use WP_Error;
 
@@ -38,13 +39,20 @@ class RestApi {
 
 		Analytics::record_usage();
 
+		$parser_error     = false;
 		$parse_time_start = microtime( true );
 
 		try {
 			$content_parser = new ContentParser();
 			$parser_results = $content_parser->parse( $post->post_content, $post_id );
 		} catch ( Exception $exception ) {
-			$error_message = sprintf( 'Error parsing post ID %d: %s', $post_id, $exception );
+			$parser_error = $exception;
+		} catch ( Error $error ) {
+			$parser_error = $error;
+		}
+
+		if ( $parser_error ) {
+			$error_message = sprintf( 'Error parsing post ID %d: %s', $post_id, $parser_error );
 			Analytics::record_error( $error_message );
 
 			$exception_data     = '';
@@ -52,12 +60,12 @@ class RestApi {
 
 			if ( ! $is_production_site && true === WP_DEBUG ) {
 				$exception_data = [
-					'stack_trace' => explode( "\n", $exception->getTraceAsString() ),
+					'stack_trace' => explode( "\n", $parser_error->getTraceAsString() ),
 				];
 			}
 
 			// Early return to skip parse time check
-			return new WP_Error( 'vip-content-api-parser-error', $exception->getMessage(), $exception_data );
+			return new WP_Error( 'vip-content-api-parser-error', $parser_error->getMessage(), $exception_data );
 		}
 
 		$parse_time    = microtime( true ) - $parse_time_start;

--- a/tests/parser/sources/test-source-children.php
+++ b/tests/parser/sources/test-source-children.php
@@ -35,17 +35,27 @@ class ChildrenSourceTest extends RegistryTestCase {
 				'name'       => 'test/custom-list-children',
 				'attributes' => [
 					'steps' => [
-						'<li>Step 1</li>',
-						'<li>Step 2</li>',
+						[
+							'type'     => 'li',
+							'children' => [
+								'Step 1',
+							],
+						],
+						[
+							'type'     => 'li',
+							'children' => [
+								'Step 2',
+							],
+						],
 					],
 				],
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
-		$blocks         = $content_parser->parse( $html );
-		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
-		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
+			$content_parser = new ContentParser( $this->registry );
+			$blocks         = $content_parser->parse( $html );
+			$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+			$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
 	}
 
 	public function test_parse_children__with_single_child() {
@@ -105,7 +115,12 @@ class ChildrenSourceTest extends RegistryTestCase {
 				'attributes' => [
 					'instructions' => [
 						'Preheat oven to',
-						'<strong>200 degrees</strong>',
+						[
+							'type'     => 'strong',
+							'children' => [
+								'200 degrees',
+							],
+						],
 					],
 				],
 			],
@@ -121,6 +136,7 @@ class ChildrenSourceTest extends RegistryTestCase {
 		$this->register_block_with_attributes( 'test/custom-block', [
 			'unused-value' => [
 				'type'     => 'array',
+				'default'  => [],
 				'source'   => 'children',
 				'selector' => '.unused-class',
 			],

--- a/tests/parser/sources/test-source-children.php
+++ b/tests/parser/sources/test-source-children.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Class ChildrenSourceTest
+ *
+ * @package vip-content-api
+ */
+
+namespace WPCOMVIP\ContentApi;
+
+/**
+ * Test sourced attributes with the deprecated 'children' type:
+ * https://github.com/WordPress/gutenberg/pull/44265
+ */
+class ChildrenSourceTest extends RegistryTestCase {
+	public function test_parse_children__with_list_elements() {
+		$this->register_block_with_attributes( 'test/custom-list-children', [
+			'steps' => [
+				'type'     => 'array',
+				'source'   => 'children',
+				'selector' => '.steps',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/custom-list-children -->
+			<ul class="steps">
+				<li>Step 1</li>
+				<li>Step 2</li>
+			</ul>
+			<!-- /wp:test/custom-list-children -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'test/custom-list-children',
+				'attributes' => [
+					'steps' => [
+						'<li>Step 1</li>',
+						'<li>Step 2</li>',
+					],
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->registry );
+		$blocks         = $content_parser->parse( $html );
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
+	}
+
+	public function test_parse_children__with_single_child() {
+		$this->register_block_with_attributes( 'test/custom-block-with-title', [
+			'title' => [
+				'type'     => 'array',
+				'source'   => 'children',
+				'selector' => 'h2',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/custom-block-with-title -->
+			<div>
+				<h2>Block title</h2>
+			</div>
+			<!-- /wp:test/custom-block-with-title -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'test/custom-block-with-title',
+				'attributes' => [
+					'title' => [
+						'Block title',
+					],
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->registry );
+		$blocks         = $content_parser->parse( $html );
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
+	}
+
+	public function test_parse_children__with_mixed_nodes_and_text() {
+		$this->register_block_with_attributes( 'test/custom-block', [
+			'instructions' => [
+				'type'     => 'array',
+				'source'   => 'children',
+				'selector' => '.instructions',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/custom-block -->
+			<div>
+				<div class="instructions">Preheat oven to <strong>200 degrees</strong></div>
+			</div>
+			<!-- /wp:test/custom-block -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'test/custom-block',
+				'attributes' => [
+					'instructions' => [
+						'Preheat oven to',
+						'<strong>200 degrees</strong>',
+					],
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->registry );
+		$blocks         = $content_parser->parse( $html );
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
+	}
+
+	public function test_parse_children__with_default_value() {
+		$this->register_block_with_attributes( 'test/custom-block', [
+			'unused-value' => [
+				'type'     => 'array',
+				'source'   => 'children',
+				'selector' => '.unused-class',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/custom-block -->
+			<p>Unrelated content</p>
+			<!-- /wp:test/custom-block -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'test/custom-block',
+				'attributes' => [
+					'unused-value' => [],
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->registry );
+		$blocks         = $content_parser->parse( $html );
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
+	}
+}

--- a/tests/parser/sources/test-source-node.php
+++ b/tests/parser/sources/test-source-node.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Class NodeSourceTest
+ *
+ * @package vip-content-api
+ */
+
+namespace WPCOMVIP\ContentApi;
+
+/**
+ * Test sourced attributes with the deprecated 'node' type:
+ * https://github.com/WordPress/gutenberg/pull/44265
+ */
+class NodeSourceTest extends RegistryTestCase {
+	public function test_parse_node__with_object_value() {
+		$this->register_block_with_attributes( 'test/custom-block', [
+			'description' => [
+				'type'     => 'object',
+				'source'   => 'node',
+				'selector' => '.description p',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/custom-block -->
+			<div class="description">
+				<p>Description text</p>
+			</div>
+			<!-- /wp:test/custom-block -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'test/custom-block',
+				'attributes' => [
+					'description' => [
+						'type'     => 'p',
+						'children' => [
+							'Description text',
+						],
+					],
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->registry );
+		$blocks         = $content_parser->parse( $html );
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
+	}
+}


### PR DESCRIPTION
## Description

The `children` and `node` attribute sources were removed from core usage in 2018 and replaced with `html`, but were not [officially deprecated until 2022](https://github.com/WordPress/gutenberg/pull/44265). Gutenberg blocks using these attributes [still exist in some examples](https://github.com/WordPress/gutenberg-examples/blob/33348e9/blocks-non-jsx/05-recipe-card/block.js#L12-L37) and should be supported.

Due to differences in how PHP's `DOMDocument` and the JS DOM treat text nodes, there may be some changes in the output of `node` and `children` attributes between the block JS implementation and the content API. If users of the API encounter problems using either of these, we can reevaluate how they're processed. For now, they should work in simple cases.
