### PR TITLE
Add REST API permissions filters

### DIFF
--- a/src/rest/rest-api.php
+++ b/src/rest/rest-api.php
@@ -36,7 +36,7 @@ class RestApi {
 						return apply_filters( 'vip_content_api__rest_validate_post_id', $is_valid, $post_id );
 					},
 					'sanitize_callback' => function( $param ) {
-							return intval( $param );
+						return intval( $param );
 					},
 				],
 			],

--- a/src/rest/rest-api.php
+++ b/src/rest/rest-api.php
@@ -23,9 +23,17 @@ class RestApi {
 			'args'                => [
 				'id' => [
 					'validate_callback' => function( $param ) {
-						$post_id      = intval( $param );
-						$is_published = 'publish' === get_post_status( $post_id );
-						return apply_filters( 'vip_content_api__rest_validate_post_id', $is_published, $post_id );
+						$post_id  = intval( $param );
+						$is_valid = 'publish' === get_post_status( $post_id );
+
+						/**
+						 * Validates a post can be queryied via the content API REST endpoint.
+						 * Return false to disable access to a post.
+						 *
+						 * @param boolean $is_valid Whether the post ID is valid for querying. Defaults to true when post status is 'publish'.
+						 * @param int $post_id The queried post ID.
+						 */
+						return apply_filters( 'vip_content_api__rest_validate_post_id', $is_valid, $post_id );
 					},
 					'sanitize_callback' => function( $param ) {
 							return intval( $param );
@@ -36,6 +44,12 @@ class RestApi {
 	}
 
 	public static function permission_callback() {
+		/**
+		 * Validates a request can access the content API. This filter can be used to limit access to authenticated users.
+		 * Return false to disable access.
+		 *
+		 * @param boolean $is_permitted Whether the request is permitted. Defaults to true.
+		 */
 		return apply_filters( 'vip_content_api__rest_permission_callback', true );
 	}
 


### PR DESCRIPTION
## Description

Add two new REST API filters for limiting access to users or posts:

### `vip_content_api__rest_validate_post_id`

```php
/**
 * Validates a post can be queryied via the content API REST endpoint.
 * Return false to disable access to a post.
 *
 * @param boolean $is_valid Whether the post ID is valid for querying. Defaults to true when post status is 'publish'.
 * @param int $post_id The queried post ID.
 */
return apply_filters( 'vip_content_api__rest_validate_post_id', $is_valid, $post_id );
```

Used to limit which post IDs are valid for querying. By default, all posts with `post_status` set to `publish` are valid.

For example, this can be used to allow only published `page` types to be available:

```php
add_filter('vip_content_api__rest_validate_post_id', function( $is_valid, $post_id ) {
    // Only allow published pages
    return 'page' === get_post_type( $post_id ) && 'publish' === get_post_status( $post_id );
}, 10, 2);
```

### `vip_content_api__rest_permission_callback`

```php
/**
 * Validates a request can access the content API. This filter can be used to limit access to authenticated users.
 * Return false to disable access.
 *
 * @param boolean $is_permitted Whether the request is permitted. Defaults to true.
 */
return apply_filters( 'vip_content_api__rest_permission_callback', true );
```

Used to test user permissions if the REST API should be locked down to specific users. For example:

```php
add_filter('vip_content_api__rest_permission_callback', function( $is_permitted ) {
    // Require authenticated user access with 'publish_posts' permission
    return current_user_can( 'publish_posts' );
});
```