### PR TITLE
Add README section on WPVIP caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,13 +749,9 @@ For another example of how this filter can be used to extend block data, we've i
 
 ## Caching on WPVIP
 
-Requests to the block data API on WPVIP will [automatically be cached][wpvip-page-cache-cached]:
+All requests to the block data API on WPVIP will automatically be cached for 1 minute. Note that authenticated requests will bypass this cache, and so care has to be taken while using the [REST permissions filter](#vip_block_data_api__rest_permission_callback).
 
-> All [WordPress REST API][wordpress-rest-api] responses are cached for 1 minute.
-
-Although the block data API is designed to be fast when uncached, we recommend relying on the default cache timeout to reduce server load and improve performance.
-
-This cache timeout only applies to unauthenticated requests to the REST API. Authenticated requests (e.g. sent with a logged-in user's cookie) [will bypass the cache][wpvip-page-cache-bypass]. If your code utilizes the [REST permissions filter](#vip_block_data_api__rest_permission_callback) to require authentication to the block data API, ensure block data API responses are cached by the API consumer.
+More information on WPVIP's caching [can be found here][wpvip-page-cache].
 
 ## Errors and Warnings
 
@@ -828,8 +824,7 @@ composer run test
 [wordpress-register-block-type-php]: https://developer.wordpress.org/reference/functions/register_block_type/
 [wordpress-rest-api]: https://docs.wpvip.com/technical-references/wordpress-rest-api/
 [wp-env]: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/
-[wpvip-page-cache-bypass]: https://docs.wpvip.com/technical-references/caching/page-cache/#h-requests-that-bypass-the-cache
-[wpvip-page-cache-cached]: https://docs.wpvip.com/technical-references/caching/page-cache/#h-requests-that-are-cached
+[wpvip-page-cache]: https://docs.wpvip.com/technical-references/caching/page-cache/
 [wpvip-plugin-activate]: https://docs.wpvip.com/how-tos/activate-plugins-through-code/
 [wpvip-plugin-submodules]: https://docs.wpvip.com/technical-references/plugins/installing-plugins-best-practices/#h-submodules
 [wpvip-plugin-subtrees]: https://docs.wpvip.com/technical-references/plugins/installing-plugins-best-practices/#h-subtrees

--- a/README.md
+++ b/README.md
@@ -810,7 +810,6 @@ composer run test
 [media-example-pullquote]: https://github.com/Automattic/vip-block-data-api/blob/media/example-pullquote.png
 [media-plugin-activate]: https://github.com/Automattic/vip-block-data-api/blob/media/plugin-activate.png
 [media-preact-media-text]: https://github.com/Automattic/vip-block-data-api/blob/media/preact-media-text.png
-[media-title-animation]: https://github.com/Automattic/vip-block-data-api/blob/media/vip-block-data-api-animation.gif
 [preact]: https://preactjs.com
 [repo-core-image-block-addition]: parser/block-additions/core-image.php
 [repo-issue-create]: https://github.com/Automattic/vip-block-data-api/issues/new/choose
@@ -822,7 +821,6 @@ composer run test
 [wordpress-block-metadata-php-registration]: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#php-server-side
 [wordpress-register-block-type-js]: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/#registerblocktype
 [wordpress-register-block-type-php]: https://developer.wordpress.org/reference/functions/register_block_type/
-[wordpress-rest-api]: https://docs.wpvip.com/technical-references/wordpress-rest-api/
 [wp-env]: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/
 [wpvip-page-cache]: https://docs.wpvip.com/technical-references/caching/page-cache/
 [wpvip-plugin-activate]: https://docs.wpvip.com/how-tos/activate-plugins-through-code/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Read on for other installation options, examples, and helpful filters that you c
 	- [`vip_block_data_api__rest_validate_post_id`](#vip_block_data_api__rest_validate_post_id)
 	- [`vip_block_data_api__rest_permission_callback`](#vip_block_data_api__rest_permission_callback)
 	- [`vip_block_data_api__sourced_block_result`](#vip_block_data_api__sourced_block_result)
-- [Caching on VIP](#caching-on-vip)
+- [Caching on WPVIP](#caching-on-wpvip)
 - [Errors and Warnings](#errors-and-warnings)
 	- [Error: `vip-block-data-api-parser-error`](#error-vip-block-data-api-parser-error)
 	- [Warning: Unregistered block type](#warning-unregistered-block-type)
@@ -696,7 +696,7 @@ Use this filter to limit block data API access to specific users or roles.
 return apply_filters( 'vip_block_data_api__rest_permission_callback', true );
 ```
 
-**Warning**: Authenticated requests to the block data API will bypass WPVIP's built-in REST API caching. See [**Caching on VIP**](#caching-on-vip) for more information.
+**Warning**: Authenticated requests to the block data API will bypass WPVIP's built-in REST API caching. See [**Caching on WPVIP**](#caching-on-wpvip) for more information.
 
 By default no authentication is required, as posts must be published to be available on the block data API. If limited access is desired, e.g. [via Application Password credentials][wordpress-application-passwords], use this filter to check user permissions:
 
@@ -747,7 +747,7 @@ Direct block HTML can be accessed through `$block['innerHTML']`. This may be use
 
 For another example of how this filter can be used to extend block data, we've implemented a default image block filter in [`parser/block-additions/core-image.php`][repo-core-image-block-addition]. This filter is automatically called on `core/image` blocks to add `width` and `height` attributes to image block attributes.
 
-## Caching on VIP
+## Caching on WPVIP
 
 Requests to the block data API on WPVIP will [automatically be cached][wpvip-page-cache-cached]:
 


### PR DESCRIPTION
Add section explaining default caching provided on WPVIP and warnings for using authenticated requests.