### PR TITLE
Update branch name in docs, bump plugin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 A REST API to retrieve block editor posts structured as JSON data. While primarily designed for use in decoupled WordPress, the block data API can be used anywhere you want to represent block markup as structured data.
 
+This plugin is currently developed for use on WPVIP sites and depends on built-in functions from [`vip-go-mu-plugins`][vip-go-mu-plugins].
+
 ## Quickstart
 
 You can get started with the Block Data API in less than five minutes.
@@ -814,6 +816,7 @@ composer run test
 [repo-core-image-block-addition]: src/parser/block-additions/core-image.php
 [repo-issue-create]: https://github.com/Automattic/vip-block-data-api/issues/new/choose
 [repo-releases]: https://github.com/Automattic/vip-block-data-api/releases
+[vip-go-mu-plugins]: https://github.com/Automattic/vip-go-mu-plugins/
 [wordpress-application-passwords]: https://make.wordpress.org/core/2020/11/05/application-passwords-integration-guide/
 [wordpress-block-attributes-html]: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#html-source
 [wordpress-block-deprecation]: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-deprecation/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Read on for other installation options, examples, and helpful filters that you c
 
 ## Installation
 
-The latest version of the VIP Block Data API plugin is available in the default `release` branch of this repository.
+The latest version of the VIP Block Data API plugin is available in the default `trunk` branch of this repository.
 
 ### Install via `git subtree`
 
@@ -59,21 +59,21 @@ We recommend installing the latest plugin version [via `git subtree`][wpvip-plug
 # Enter your project's root directory:
 cd my-site/
 
-# Add a subtree for the release branch:
-git subtree add --prefix plugins/vip-block-data-api git@github.com:Automattic/vip-block-data-api.git release --squash
+# Add a subtree for the trunk branch:
+git subtree add --prefix plugins/vip-block-data-api git@github.com:Automattic/vip-block-data-api.git trunk --squash
 ```
 
 To deploy the plugin to a remote branch, `git push` the committed subtree.
 
-The `release` branch will stay up to date with the latest released version of the plugin. Use this command to pull the latest `release` branch changes:
+The `trunk` branch will stay up to date with the latest version of the plugin. Use this command to pull the latest `trunk` branch changes:
 
 ```bash
-git subtree pull --prefix plugins/vip-block-data-api git@github.com:Automattic/vip-block-data-api.git release --squash
+git subtree pull --prefix plugins/vip-block-data-api git@github.com:Automattic/vip-block-data-api.git trunk --squash
 ```
 
 **BETA**: We anticipate frequent updates to the block data API plugin during beta testing. Please ensure the plugin is up-to-date by pulling changes often.
 
-Note: We **do not recommend** using `git submodule` as [submodules that require authentication][wpvip-plugin-submodules] will fail to deploy.
+Note: We **do not recommend** using `git submodule` as [submodules on WPVIP that require authentication][wpvip-plugin-submodules] will fail to deploy.
 
 ### Install via ZIP file
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,17 +5,9 @@
 1. Update plugin version in `vip-block-data-api.php`. Change plugin header and `WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION` to match new version.
 2. PR and merge to `trunk`.
 
-## 2. Merge to `release` branch and tag
+## 2. Tag branch for release
 
-1. Merge `trunk` changes into the `release` branch:
-
-    ```bash
-    git checkout release
-    git merge trunk
-    ```
-
-2. If `composer` dependencies have changed, run `composer install --no-dev` and commit changes.
-3. Add a tag for the release:
+1. Add a tag for the release:
 
     ```bash
     git tag -a <version> -m "Release <version>"
@@ -23,14 +15,14 @@
     # e.g. git tag -a v0.1.0-alpha -m "Release v0.1.0-alpha"
     ```
 
-5. Run `git push --tags`.
+2. Run `git push --tags`.
 
 ## 3. Create a release
 
 1. In the `vip-block-data-api` folder, run this command to create a plugin ZIP:
 
     ```bash
-    zip -r - ./ -x "./.*" "./.*/*" "*.zip" > vip-block-data-api.zip
+    zip -r - ./ -x "./.*" "./.*/*" "*.zip" > vip-block-data-api-<version>.zip
 
     # -r: Recursively
     # - : Output to STDOUT

--- a/vip-block-data-api.php
+++ b/vip-block-data-api.php
@@ -5,7 +5,7 @@
  * Description: Access Gutenberg block data in JSON via the REST API.
  * Author: WordPress VIP
  * Text Domain: vip-block-data-api
- * Version: 0.1.0
+ * Version: 0.1.1
  * Requires at least: 5.6.0
  * Tested up to: 6.1.0
  * Requires PHP: 7.4
@@ -17,7 +17,7 @@
 
 namespace WPCOMVIP\BlockDataApi;
 
-define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '0.1.0' );
+define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '0.1.1' );
 define( 'WPCOMVIP__BLOCK_DATA_API__REST_ROUTE', 'vip-block-data-api/v1' );
 
 // Composer dependencies


### PR DESCRIPTION
## Description

We're switching from a separate `develop`/`release` branches to a less complicated single `trunk` branch which follows the latest changes. In this PR we're changing the documentation to match and adding a new release to test the process.
 
We had some issues with separate branches:

- When `release` was set to the default branch, PRs automatically went against `release` instead of `develop`. Normally we'd want to merge to `develop` and then to `release`, so this made things default to confusing.
- Initially we tried to keep the composer dependencies in `release` the `--no-dev` folders needed for running the plugin, and `develop` had the full set of developer dependencies. This made merges and git history complicated.
