### PR TITLE
Add error for classic content

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Other installation options, examples, and helpful filters for customizing the AP
 	- [`vip_block_data_api__sourced_block_result`](#vip_block_data_api__sourced_block_result)
 - [Caching on WPVIP](#caching-on-wpvip)
 - [Errors and Warnings](#errors-and-warnings)
+	- [Error: `vip-block-data-api-no-blocks`](#error-vip-block-data-api-no-blocks)
 	- [Error: `vip-block-data-api-parser-error`](#error-vip-block-data-api-parser-error)
 	- [Warning: Unregistered block type](#warning-unregistered-block-type)
 - [Development](#development)
@@ -761,6 +762,17 @@ More information about WPVIP's caching [can be found here][wpvip-page-cache].
 
 ## Errors and Warnings
 
+### Error: `vip-block-data-api-no-blocks`
+
+The VIP Block Data API is designed to parse structured block data, and can not read content from WordPress before the release of Gutenberg in [WordPress 5.0][wordpress-release-5-0] or created using the [classic editor plugin][wordpress-plugin-classic-editor]. If the parser encounters post content that does not contain block data, this error will be returned with an HTTP `500` response code:
+
+```js
+{
+  "code": "vip-block-data-api-no-blocks",
+  "message": "Error parsing post ID ...: This post does not appear to contain block content. The VIP Block Data API is designed to parse Gutenberg blocks and can not read classic editor content.",
+}
+```
+
 ### Error: `vip-block-data-api-parser-error`
 
 If any unexpected errors are encountered during block parsing, the block API will return error data with an HTTP `500` response code:
@@ -832,8 +844,10 @@ composer run test
 [wordpress-block-deprecation]: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-deprecation/
 [wordpress-block-json-recommendation]: https://make.wordpress.org/core/2021/06/23/block-api-enhancements-in-wordpress-5-8/
 [wordpress-block-metadata-php-registration]: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#php-server-side
+[wordpress-plugin-classic-editor]: https://wordpress.org/plugins/classic-editor/
 [wordpress-register-block-type-js]: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/#registerblocktype
 [wordpress-register-block-type-php]: https://developer.wordpress.org/reference/functions/register_block_type/
+[wordpress-release-5-0]: https://wordpress.org/documentation/wordpress-version/version-5-0/
 [wp-env]: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/
 [wpvip-page-cache]: https://docs.wpvip.com/technical-references/caching/page-cache/
 [wpvip-plugin-activate]: https://docs.wpvip.com/how-tos/activate-plugins-through-code/

--- a/README.md
+++ b/README.md
@@ -764,12 +764,12 @@ More information about WPVIP's caching [can be found here][wpvip-page-cache].
 
 ### Error: `vip-block-data-api-no-blocks`
 
-The VIP Block Data API is designed to parse structured block data, and can not read content from WordPress before the release of Gutenberg in [WordPress 5.0][wordpress-release-5-0] or created using the [classic editor plugin][wordpress-plugin-classic-editor]. If the parser encounters post content that does not contain block data, this error will be returned with an HTTP `500` response code:
+The VIP Block Data API is designed to parse structured block data, and can not read content from WordPress before the release of Gutenberg in [WordPress 5.0][wordpress-release-5-0] or created using the [classic editor plugin][wordpress-plugin-classic-editor]. If the parser encounters post content that does not contain block data, this error will be returned with an HTTP `400` response code:
 
 ```js
 {
   "code": "vip-block-data-api-no-blocks",
-  "message": "Error parsing post ID ...: This post does not appear to contain block content. The VIP Block Data API is designed to parse Gutenberg blocks and can not read classic editor content.",
+  "message": "Error parsing post ID ...: This post does not appear to contain block content. The VIP Block Data API is designed to parse Gutenberg blocks and can not read classic editor content."
 }
 ```
 

--- a/src/analytics/analytics.php
+++ b/src/analytics/analytics.php
@@ -18,11 +18,23 @@ class Analytics {
 		self::$analytics_to_send[ WPCOMVIP__BLOCK_DATA_API__STAT_NAME__USAGE ] = self::get_identifier();
 	}
 
+	/**
+	 * @param WP_Error $error
+	 *
+	 * @return void
+	 */
 	public static function record_error( $error ) {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		trigger_error( sprintf( 'vip-block-data-api (%s): %s', WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION, $error ), E_USER_WARNING );
+		$error_data           = $error->get_error_data();
+		$error_data_formatted = $error_data ? sprintf( ' - %s', $error_data ) : '';
 
-		if ( self::is_wpvip_site() && defined( 'FILES_CLIENT_SITE_ID' ) ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		trigger_error( sprintf( 'vip-block-data-api (%s): %s - %s%s', WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION, $error->get_error_code(), $error->get_error_message(), $error_data_formatted ), E_USER_WARNING );
+
+		$is_skippable_error_for_analytics = in_array( $error->get_error_code(), [
+			'vip-block-data-api-no-blocks',
+		] );
+
+		if ( self::is_wpvip_site() && defined( 'FILES_CLIENT_SITE_ID' ) && ! $is_skippable_error_for_analytics ) {
 			// Record error data from WPVIP for follow-up
 			self::$analytics_to_send[ WPCOMVIP__BLOCK_DATA_API__STAT_NAME__ERROR ] = constant( 'FILES_CLIENT_SITE_ID' );
 		}

--- a/src/analytics/analytics.php
+++ b/src/analytics/analytics.php
@@ -24,11 +24,11 @@ class Analytics {
 	 * @return void
 	 */
 	public static function record_error( $error ) {
-		$error_data           = $error->get_error_data();
-		$error_data_formatted = $error_data ? sprintf( ' - %s', $error_data ) : '';
+		$error_data    = $error->get_error_data();
+		$error_details = isset( $error_data['details'] ) ? sprintf( ' - %s', ( $error_data['details'] ) ) : '';
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		trigger_error( sprintf( 'vip-block-data-api (%s): %s - %s%s', WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION, $error->get_error_code(), $error->get_error_message(), $error_data_formatted ), E_USER_WARNING );
+		trigger_error( sprintf( 'vip-block-data-api (%s): %s - %s%s', WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION, $error->get_error_code(), $error->get_error_message(), $error_details ), E_USER_WARNING );
 
 		$is_skippable_error_for_analytics = in_array( $error->get_error_code(), [
 			'vip-block-data-api-no-blocks',

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -44,7 +44,7 @@ class ContentParser {
 				'The VIP Block Data API is designed to parse Gutenberg blocks and can not read classic editor content.',
 			] );
 
-			return new WP_Error( 'vip-block-data-api-no-blocks', $error_message );
+			return new WP_Error( 'vip-block-data-api-no-blocks', $error_message, [ 'status' => 400 ] );
 		}
 
 		$parsing_error = false;
@@ -83,7 +83,10 @@ class ContentParser {
 
 		if ( $parsing_error ) {
 			$error_message = sprintf( 'Error parsing post ID %d: %s', $post_id, $parsing_error->getMessage() );
-			return new WP_Error( 'vip-block-data-api-parser-error', $error_message, $parsing_error->__toString() );
+			return new WP_Error( 'vip-block-data-api-parser-error', $error_message, [
+				'status'  => 500,
+				'details' => $parsing_error->__toString(),
+			] );
 		} else {
 			return $result;
 		}

--- a/src/rest/rest-api.php
+++ b/src/rest/rest-api.php
@@ -60,24 +60,16 @@ class RestApi {
 
 		Analytics::record_usage();
 
-		$parser_error     = false;
 		$parse_time_start = microtime( true );
 
-		try {
-			$content_parser = new ContentParser();
-			$parser_results = $content_parser->parse( $post->post_content, $post_id );
-		} catch ( Exception $exception ) {
-			$parser_error = $exception;
-		} catch ( Error $error ) {
-			$parser_error = $error;
-		}
+		$content_parser = new ContentParser();
+		$parser_results = $content_parser->parse( $post->post_content, $post_id );
 
-		if ( $parser_error ) {
-			Analytics::record_error( $parser_error );
-			$error_message = sprintf( 'Error parsing post ID %d: %s', $post_id, $parser_error->getMessage() );
+		if ( is_wp_error( $parser_results ) ) {
+			Analytics::record_error( $parser_results );
 
-			// Early return to skip parse time check
-			return new WP_Error( 'vip-block-data-api-parser-error', $error_message );
+			// Return API-safe error with extra data (e.g. stack trace) removed
+			return new WP_Error( $parser_results->get_error_code(), $parser_results->get_error_message() );
 		}
 
 		$parse_time    = microtime( true ) - $parse_time_start;
@@ -85,7 +77,9 @@ class RestApi {
 
 		if ( $parse_time_ms > WPCOMVIP__BLOCK_DATA_API__PARSE_TIME_ERROR_MS ) {
 			$error_message = sprintf( 'Parse time for post ID %d exceeded threshold: %dms', $post_id, $parse_time_ms );
-			Analytics::record_error( $error_message );
+
+			// Record error silently, still return results
+			Analytics::record_error( new WP_Error( 'vip-block-data-api-parser-time', $error_message ) );
 		}
 
 		return $parser_results;

--- a/src/rest/rest-api.php
+++ b/src/rest/rest-api.php
@@ -68,8 +68,16 @@ class RestApi {
 		if ( is_wp_error( $parser_results ) ) {
 			Analytics::record_error( $parser_results );
 
+			$original_error_data = $parser_results->get_error_data();
+			$wp_error_data       = '';
+
+			// Forward HTTP status if present in WP_Error
+			if ( isset( $original_error_data['status'] ) ) {
+				$wp_error_data = [ 'status' => intval( $original_error_data['status'] ) ];
+			}
+
 			// Return API-safe error with extra data (e.g. stack trace) removed
-			return new WP_Error( $parser_results->get_error_code(), $parser_results->get_error_message() );
+			return new WP_Error( $parser_results->get_error_code(), $parser_results->get_error_message(), $wp_error_data );
 		}
 
 		$parse_time    = microtime( true ) - $parse_time_start;

--- a/tests/rest/test-rest-api.php
+++ b/tests/rest/test-rest-api.php
@@ -161,11 +161,11 @@ class RestApiTest extends WP_UnitTestCase {
 		wp_delete_post( $post_id );
 	}
 
-	/**
-	 * @expectedException PHPUnit\Framework\Error\Error
-	 */
 	public function test_rest_api_returns_error_for_classic_content() {
 		$post_id = $this->get_post_id_with_content( '<p>Classic editor content</p>' );
+
+		// Ignore exception created by PHPUnit called when trigger_error() is called internally
+		$this->expectException( \PHPUnit\Framework\Error\Error::class );
 
 		$request  = new WP_REST_Request( 'GET', sprintf( '/vip-block-data-api/v1/posts/%d/blocks', $post_id ) );
 		$response = $this->server->dispatch( $request );
@@ -180,15 +180,15 @@ class RestApiTest extends WP_UnitTestCase {
 		wp_delete_post( $post_id );
 	}
 
-	/**
-	 * @expectedException PHPUnit\Framework\Error\Error
-	 */
 	public function test_rest_api_returns_error_for_unexpected_exception() {
 		$post_id = $this->get_post_id_with_content( '<!-- wp:paragraph --><p>Content</p><!-- /wp:paragraph -->' );
 
 		$exception_causing_parser_function = function( $sourced_block, $block_name, $post_id, $block ) {
 			throw new Exception( 'Exception in parser' );
 		};
+
+		// Ignore exception created by PHPUnit called when trigger_error() is called internally
+		$this->expectException( \PHPUnit\Framework\Error\Error::class );
 
 		add_filter( 'vip_block_data_api__sourced_block_result', $exception_causing_parser_function );
 		$request  = new WP_REST_Request( 'GET', sprintf( '/vip-block-data-api/v1/posts/%d/blocks', $post_id ) );

--- a/vip-block-data-api.php
+++ b/vip-block-data-api.php
@@ -5,7 +5,7 @@
  * Description: Access Gutenberg block data in JSON via the REST API.
  * Author: WordPress VIP
  * Text Domain: vip-block-data-api
- * Version: 0.1.2
+ * Version: 0.2.0
  * Requires at least: 5.6.0
  * Tested up to: 6.1.0
  * Requires PHP: 7.4
@@ -17,7 +17,7 @@
 
 namespace WPCOMVIP\BlockDataApi;
 
-define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '0.1.2' );
+define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '0.2.0' );
 define( 'WPCOMVIP__BLOCK_DATA_API__REST_ROUTE', 'vip-block-data-api/v1' );
 
 // Composer dependencies


### PR DESCRIPTION
## Description

Currently when the VIP Block Data API encounters classic editor content, the API returns an unusual result:

```json
{
  "blocks": [
    {
      "name": null,
      "attributes": {}
    }
  ],
  "warnings": [
    "Block type \"\" is not server-side registered. Sourced block attributes will not be available."
  ]
}
```

This PR fixes this response by using [`has_blocks()`](https://developer.wordpress.org/reference/functions/has_blocks/) before parsing content. If [no blocks are detected](https://github.com/WordPress/wordpress-develop/blob/6.2/src/wp-includes/blocks.php#L578), the REST API responds with a `400` and an error message indicating the issue. For example:

```js
{
  "code": "vip-block-data-api-no-blocks",
  "message": "Error parsing post ID 68: This post does not appear to contain block content. The VIP Block Data API is designed to parse Gutenberg blocks and can not read classic editor content."
}
```

### Other changes

- In order to support this error, the `ContentParser::parse()` function has been changed to internally `try`/`catch` errors and return a `WP_Error`.
- README has been updated with the new `vip-block-data-api-no-blocks` error code.

## Steps to Test

This can be tested by installing the [classic editor plugin](https://wordpress.org/plugins/classic-editor/), making a classic post, and requesting post data from the Block Data API.
