### PR TITLE
Improve default post access to be more restrictive

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ Limit which post IDs are valid in the REST API. By default, posts that are avail
  *
  * @param boolean $is_valid Whether the post ID is valid for querying. Defaults to true
  *                          when a post is available via the WordPress REST API.
- * @param int $post_id The queried post ID.
+ * @param int     $post_id  The queried post ID.
  */
 return apply_filters( 'vip_block_data_api__rest_validate_post_id', $is_valid, $post_id );
 ```

--- a/README.md
+++ b/README.md
@@ -663,16 +663,16 @@ Block Data API filters can be applied to limit access to the REST API and modify
 
 ### `vip_block_data_api__rest_validate_post_id`
 
-Limit which post IDs are valid in the REST API. By default, all posts with `post_status` set to `publish` are valid.
+Limit which post IDs are valid in the REST API. By default, posts that are available via the [WordPress `/posts` REST API][wordpress-rest-api-posts] are queryable.
 
 ```php
 /**
  * Validates that a post can be queried via the Block Data API REST endpoint.
  * Return false to disable access to a post.
  *
- * @param boolean $is_valid Whether the post ID is valid for querying.
- *                          Defaults to true when post status is 'publish'.
- * @param int     $post_id  The queried post ID.
+ * @param boolean $is_valid Whether the post ID is valid for querying. Defaults to true
+ *                          when a post is available via the WordPress REST API.
+ * @param int $post_id The queried post ID.
  */
 return apply_filters( 'vip_block_data_api__rest_validate_post_id', $is_valid, $post_id );
 ```
@@ -848,6 +848,7 @@ composer run test
 [wordpress-register-block-type-js]: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/#registerblocktype
 [wordpress-register-block-type-php]: https://developer.wordpress.org/reference/functions/register_block_type/
 [wordpress-release-5-0]: https://wordpress.org/documentation/wordpress-version/version-5-0/
+[wordpress-rest-api-posts]: https://developer.wordpress.org/rest-api/reference/posts/
 [wp-env]: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/
 [wpvip-page-cache]: https://docs.wpvip.com/technical-references/caching/page-cache/
 [wpvip-plugin-activate]: https://docs.wpvip.com/how-tos/activate-plugins-through-code/

--- a/src/rest/rest-api.php
+++ b/src/rest/rest-api.php
@@ -2,8 +2,6 @@
 
 namespace WPCOMVIP\BlockDataApi;
 
-use Error;
-use Exception;
 use WP_Error;
 
 defined( 'ABSPATH' ) || die();
@@ -24,7 +22,7 @@ class RestApi {
 				'id' => [
 					'validate_callback' => function( $param ) {
 						$post_id  = intval( $param );
-						$is_valid = 'publish' === get_post_status( $post_id );
+						$is_valid = self::is_post_readable( $post_id );
 
 						/**
 						 * Validates that a post can be queried via the Block Data API REST endpoint.
@@ -91,6 +89,46 @@ class RestApi {
 		}
 
 		return $parser_results;
+	}
+
+	private static function is_post_readable( $post_id ) {
+		// Borrow logic from WP_REST_Posts_Controller->check_read_permission()
+		// to only allow REST-accessible posts by default
+
+		$post = get_post( $post_id );
+
+		if ( empty( $post ) || empty( $post->ID ) ) {
+			return false;
+		}
+
+		$post_type = get_post_type_object( $post->post_type );
+		if ( empty( $post_type ) || empty( $post_type->show_in_rest ) ) {
+			return false;
+		}
+
+		if ( 'publish' === $post->post_status || current_user_can( 'read_post', $post->ID ) ) {
+			return true;
+		}
+
+		$post_status_obj = get_post_status_object( $post->post_status );
+		if ( $post_status_obj && $post_status_obj->public ) {
+			return true;
+		}
+
+		// Use parent status if inheriting
+		if ( 'inherit' === $post->post_status && $post->post_parent > 0 ) {
+			return self::is_post_readable( $post->post_parent );
+		}
+
+		/*
+		 * If there isn't a parent, but the status is set to inherit, assume
+		 * it's published (as per get_post_status()).
+		 */
+		if ( 'inherit' === $post->post_status ) {
+			return true;
+		}
+
+		return false;
 	}
 }
 

--- a/src/rest/rest-api.php
+++ b/src/rest/rest-api.php
@@ -28,7 +28,8 @@ class RestApi {
 						 * Validates that a post can be queried via the Block Data API REST endpoint.
 						 * Return false to disable access to a post.
 						 *
-						 * @param boolean $is_valid Whether the post ID is valid for querying. Defaults to true when post status is 'publish'.
+						 * @param boolean $is_valid Whether the post ID is valid for querying. Defaults to true
+						 *                          when a post is available via the WordPress REST API.
 						 * @param int $post_id The queried post ID.
 						 */
 						return apply_filters( 'vip_block_data_api__rest_validate_post_id', $is_valid, $post_id );

--- a/tests/rest/test-rest-api.php
+++ b/tests/rest/test-rest-api.php
@@ -140,6 +140,102 @@ class RestApiTest extends WP_UnitTestCase {
 		wp_delete_post( $post_id );
 	}
 
+	public function test_rest_api_returns_blocks_for_custom_post_type() {
+		$test_post_type = register_post_type( 'vip-test-post-type1', [
+			'public'       => true,
+			'show_in_rest' => true,
+		]);
+
+		$html = '
+			<!-- wp:paragraph -->
+			<p>Text in custom post type</p>
+			<!-- /wp:paragraph -->
+		';
+
+		$post_id = $this->factory()->post->create( [
+			'post_title'   => 'Custom published post',
+			'post_type'    => $test_post_type->name,
+			'post_content' => $html,
+			'post_status'  => 'publish',
+		] );
+
+		$expected_blocks = [
+			[
+				'name'       => 'core/paragraph',
+				'attributes' => [
+					'content' => 'Text in custom post type',
+					'dropCap' => false,
+				],
+			],
+		];
+
+		$request  = new WP_REST_Request( 'GET', sprintf( '/vip-block-data-api/v1/posts/%d/blocks', $post_id ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$result = $response->get_data();
+		$this->assertArrayHasKey( 'blocks', $result, sprintf( 'Unexpected REST output: %s', wp_json_encode( $result ) ) );
+		$this->assertEquals( $expected_blocks, $result['blocks'] );
+		$this->assertArrayNotHasKey( 'warnings', $result );
+
+		wp_delete_post( $post_id );
+		unregister_post_type( $test_post_type->name );
+	}
+
+	public function test_rest_api_returns_error_for_non_public_post_type() {
+		$test_post_type = register_post_type( 'vip-test-post-type2', [
+			'public' => false,
+		]);
+
+		$post_id = $this->factory()->post->create( [
+			'post_title'   => 'Custom post type',
+			'post_type'    => $test_post_type->name,
+			'post_content' => '<!-- wp:paragraph --><p>Custom post type content</p><!-- /wp:paragraph -->',
+			'post_status'  => 'publish',
+		] );
+
+		$request  = new WP_REST_Request( 'GET', sprintf( '/vip-block-data-api/v1/posts/%d/blocks', $post_id ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+
+		$result = $response->get_data();
+		$this->assertArrayNotHasKey( 'blocks', $result );
+		$this->assertArrayHasKey( 'code', $result );
+		$this->assertEquals( 'rest_invalid_param', $result['code'] );
+
+		wp_delete_post( $post_id );
+		unregister_post_type( $test_post_type->name );
+	}
+
+	public function test_rest_api_returns_error_for_non_rest_post_type() {
+		$test_post_type = register_post_type( 'vip-test-post-type3', [
+			'public'       => true,
+			'show_in_rest' => false,
+		]);
+
+		$post_id = $this->factory()->post->create( [
+			'post_title'   => 'Custom post type',
+			'post_type'    => $test_post_type->name,
+			'post_content' => '<!-- wp:paragraph --><p>Custom post type content</p><!-- /wp:paragraph -->',
+			'post_status'  => 'publish',
+		] );
+
+		$request  = new WP_REST_Request( 'GET', sprintf( '/vip-block-data-api/v1/posts/%d/blocks', $post_id ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+
+		$result = $response->get_data();
+		$this->assertArrayNotHasKey( 'blocks', $result );
+		$this->assertArrayHasKey( 'code', $result );
+		$this->assertEquals( 'rest_invalid_param', $result['code'] );
+
+		wp_delete_post( $post_id );
+		unregister_post_type( $test_post_type->name );
+	}
+
 	public function test_rest_api_returns_error_for_unpublished_post() {
 		$post_id = $this->factory()->post->create( [
 			'post_title'   => 'Unpublished post',


### PR DESCRIPTION
## Description

Previously, the Block Data API verified posts were readable [using the `'publish'` status](https://github.com/Automattic/vip-block-data-api/blob/e28e441/src/rest/rest-api.php#L24-L27). This provides basic access limitations to posts in the REST API, but isn't as restrictive as WordPress' built-in REST API.

For example, the Block Data API can be used to access a custom post type with the `publish` status that isn't allowed by the REST API:

1. First a custom post type is registered with `'public' => false`:

    ```php
    register_post_type( 'vip-test-post-type', [
        'public' => false,
    ]);
    ```

2. A post is created with that type:

    ```bash
    $ wp post create --post_type="vip-test-post-type" --post_title="Custom post_type" \
           --post_content='<!-- wp:paragraph --><p>Custom post_type content</p><!-- /wp:paragraph -->' \
           --post_status="publish"
    Success: Created post 12.
    ```

3. If the post is queried via the built-in REST API, the post is not accessible:

    ```
    GET /wp-json/wp/v2/posts/12
    
    {"code":"rest_post_invalid_id","message":"Invalid post ID.","data":{"status":404}}
    ```

4. However, the same post was accessible through the block data API due to the `publish` status:

    ```
    GET /wp-json/vip-block-data-api/v1/posts/12/blocks

    {"blocks":[{"name":"core\/paragraph","attributes":{"content":"Custom post_type content","dropCap":false}}]}
    ```

This has been fixed to use logic based on WordPress' [`WP_REST_Posts_Controller->check_read_permission()`](https://github.com/WordPress/WordPress/blob/1764cee/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L1648) function.

The WordPress REST function is not used directly, as instantiating the REST controller and calling `check_read_permission()` for a single post is not the intended flow of the class, and can sometimes generate warnings from uninitialized variables. Rather than depending on an internal flow of a specialized class, we moved the permission checking defaults into [`is_post_readable()`](https://github.com/Automattic/vip-block-data-api/blob/9ace90669c5780f60fd3fb5e7f54393f5b8fc94c/src/rest/rest-api.php#L94).

Now when the same non-public post is queried by the block API, it is rejected:

```
GET /wp-json/vip-block-data-api/v1/posts/12/blocks

{"code":"rest_invalid_param","message":"Invalid parameter(s): id","data":{"status":400,"params":{"id":"Invalid parameter."},"details":[]}}
```

## Steps to Test

Three tests were added to verify this functionality in https://github.com/Automattic/vip-block-data-api/commit/5bf567b3fdfc1c9bbd921d0491c4d33fc2600807:

1. `test_rest_api_returns_blocks_for_custom_post_type()`: Ensure custom post types with `'public' => true` and `'show_in_rest' => true` are returned by the Block Data API successfully.
2. `test_rest_api_returns_error_for_non_public_post_type()`: Ensure custom post types with `'public' => false` result in an invalid ID error.
3. `test_rest_api_returns_error_for_non_rest_post_type()`: Ensure custom post types with `'public' => true` but `'show_in_rest' => false` also result in an invalid ID error.

These match the behavior of the default REST API.