### PR TITLE
Add guard against double-loading plugin

### DIFF
--- a/vip-block-data-api.php
+++ b/vip-block-data-api.php
@@ -17,18 +17,22 @@
 
 namespace WPCOMVIP\BlockDataApi;
 
-define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '0.2.0' );
-define( 'WPCOMVIP__BLOCK_DATA_API__REST_ROUTE', 'vip-block-data-api/v1' );
+if ( ! defined( 'VIP_BLOCK_DATA_API_LOADED' ) ) {
+	define( 'VIP_BLOCK_DATA_API_LOADED', true );
 
-// Composer dependencies
-require_once __DIR__ . '/vendor/autoload.php';
+	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '0.2.0' );
+	define( 'WPCOMVIP__BLOCK_DATA_API__REST_ROUTE', 'vip-block-data-api/v1' );
 
-// /wp-json/ API
-require_once __DIR__ . '/src/rest/rest-api.php';
+	// Composer dependencies
+	require_once __DIR__ . '/vendor/autoload.php';
 
-// Block parsing
-require_once __DIR__ . '/src/parser/content-parser.php';
-require_once __DIR__ . '/src/parser/block-additions/core-image.php';
+	// /wp-json/ API
+	require_once __DIR__ . '/src/rest/rest-api.php';
 
-// Analytics
-require_once __DIR__ . '/src/analytics/analytics.php';
+	// Block parsing
+	require_once __DIR__ . '/src/parser/content-parser.php';
+	require_once __DIR__ . '/src/parser/block-additions/core-image.php';
+
+	// Analytics
+	require_once __DIR__ . '/src/analytics/analytics.php';
+}


### PR DESCRIPTION
## Description

Add a `VIP_BLOCK_DATA_API_LOADED` constant to prevent against double-loading plugin. This is helpful if a plugin is loaded via mu-plugins and is also installed. The changes here delegate the responsibility of what to do in that situation (prefer mu-plugins or `/plugins` version) to the code that loads the plugin. The plugin's responsibility is only to ensure that it's loaded once.

The code here wraps all loading code and uses a constant for these reasons:

1. Checking for class or function names (e.g. `class_exists("WPCOMVIP\BlockDataApi")`) is brittle. Future refactorings would create the need for fallback class names which would increase complexity.
2. All of the `require_once` code is wrapped in an if clause to prevent PHP compilation errors from double-defined classes. For example, if the header uses an early return instead:

    ```php
    if ( defined( 'VIP_BLOCK_DATA_API_LOADED' ) ) {
        return;
    }

    // ...

    require_once __DIR__ . '/vendor/autoload.php';
    ```

    Composer's `ComposerAutoloaderInit...` class causes an error from being defined twice during compilation, before the code is even run. Wrapping `require_once`s in the if statement removes this problem.