### PR TITLE
Planned release 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VIP Block Data API (Beta)
+# VIP Block Data API
 
 <picture>
   <source srcset="https://github.com/Automattic/vip-block-data-api/blob/media/vip-block-data-api-animation-1660.gif" media="(-webkit-min-device-pixel-ratio: 2.0)" />
@@ -79,7 +79,7 @@ The `trunk` branch will stay up to date with the latest version of the plugin. U
 git subtree pull --prefix plugins/vip-block-data-api git@github.com:Automattic/vip-block-data-api.git trunk --squash
 ```
 
-**BETA**: We anticipate frequent updates to the VIP Block Data API plugin during beta testing. Ensure that the plugin is up-to-date by pulling changes often.
+Ensure that the plugin is up-to-date by pulling changes often.
 
 Note: We **do not recommend** using `git submodule`. [Submodules on WPVIP that require authentication][wpvip-plugin-submodules] will fail to deploy.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-----
-### :warning: This plugin is currently in Beta. It is designed to run on [WordPress VIP](https://wpvip.com). This beta release is not intended for use on a production environment.
-----
-
 # VIP Block Data API (Beta)
 
 <picture>
@@ -713,7 +709,7 @@ Note that custom block filter rules can also be created in code via [the `vip_bl
 
 ### `exclude`
 
-Exclude some block types from the Block Data API. This can be useful for providing a block list of unsupported blocks and skipping those in REST API output. Multiple block types can be specified using commas, e.g. `?include=core/heading,core/paragraph`.
+Exclude some block types from the Block Data API. This can be useful for providing a block list of unsupported blocks and skipping those in REST API output. Multiple block types can be specified using commas, e.g. `?exclude=core/heading,core/paragraph`.
 
 Example: using the [post data above](#example-post) with `?exclude=core/heading`, skip `core/heading` blocks in the output:
 

--- a/vip-block-data-api.php
+++ b/vip-block-data-api.php
@@ -5,7 +5,7 @@
  * Description: Access Gutenberg block data in JSON via the REST API.
  * Author: WordPress VIP
  * Text Domain: vip-block-data-api
- * Version: 0.2.1
+ * Version: 1.0.0
  * Requires at least: 5.6.0
  * Tested up to: 6.1.0
  * Requires PHP: 7.4
@@ -20,7 +20,7 @@ namespace WPCOMVIP\BlockDataApi;
 if ( ! defined( 'VIP_BLOCK_DATA_API_LOADED' ) ) {
 	define( 'VIP_BLOCK_DATA_API_LOADED', true );
 
-	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '0.2.1' );
+	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '1.0.0' );
 	define( 'WPCOMVIP__BLOCK_DATA_API__REST_ROUTE', 'vip-block-data-api/v1' );
 
 	// Composer dependencies


### PR DESCRIPTION
## Description

We're ready for a non-beta release! No functional changes, we're just removing "beta" header, some beta-related text, and updating the version to `1.0.0`.