### PR TITLE
Ability to turn off analytics for non-VIP sites

### DIFF
--- a/src/analytics/analytics.php
+++ b/src/analytics/analytics.php
@@ -57,6 +57,12 @@ class Analytics {
 	}
 
 	private static function send_pixel( $stats ) {
+		$can_send = apply_filters( 'vip-block-data-api/analytics', false );
+		// Always send on VIP sites
+		if ( ! self::is_wpvip_site() && ! $can_send ) {
+			return;
+		}
+
 		$query_args = [
 			'v' => 'wpcom-no-pv',
 		];


### PR DESCRIPTION
## Description

An example of solving #39. I expect the readme changes and filter name will need adjusting. I'd also recommend a non-american engineer look at this.

I'd also suggest differentiating further between VIP sites running locally, and VIP sites running in production. Do you really want your analytics gummed up with CI test runs and local dev environments?