### PR TITLE
Add PHPDocs and add it to the phpcs workflow

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -21,6 +21,9 @@
 	<!-- https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
 	<config name="testVersion" value="7.4-"/>
 
+	<rule ref="WordPress-Docs">
+		<exclude-pattern>/tests</exclude-pattern>
+	</rule>
 	<!-- Rules: WordPress Coding Standards - see
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
 	<!-- WordPress-Extra includes WordPress-Core -->

--- a/src/analytics/analytics.php
+++ b/src/analytics/analytics.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Analytics
+ * 
+ * @file
+ * @package vip-block-data-api
+ */
 
 namespace WPCOMVIP\BlockDataApi;
 
@@ -7,9 +13,20 @@ defined( 'ABSPATH' ) || die();
 define( 'WPCOMVIP__BLOCK_DATA_API__STAT_NAME__USAGE', 'vip-block-data-api-usage' );
 define( 'WPCOMVIP__BLOCK_DATA_API__STAT_NAME__ERROR', 'vip-block-data-api-error' );
 
+/**
+ * Analytics Class that will be used to send data to the WP Pixel.
+ */
 class Analytics {
+	/**
+	 * Array of analytics to send to the WP Pixel.
+	 * 
+	 * @var array
+	 */
 	private static $analytics_to_send = [];
 
+	/**
+	 * Initialize the Analytics class.
+	 */
 	public static function init() {
 		add_action( 'shutdown', [ __CLASS__, 'send_analytics' ] );
 	}

--- a/src/analytics/analytics.php
+++ b/src/analytics/analytics.php
@@ -14,7 +14,10 @@ class Analytics {
 		add_action( 'shutdown', [ __CLASS__, 'send_analytics' ] );
 	}
 
-	public static function record_usage() {
+	/**
+	 * Record the usage of the plugin, for VIP sites only. For non-VIP sites, this is a no-op.
+	 */
+	public static function record_usage(): void {
 		// Record usage on WPVIP sites only
 		if ( ! self::is_wpvip_site() ) {
 			return;
@@ -24,11 +27,13 @@ class Analytics {
 	}
 
 	/**
+	 * Record an error if it's allowed, for VIP sites only. For non-VIP sites, this is a no-op.
+	 * 
 	 * @param WP_Error $error
 	 *
 	 * @return void
 	 */
-	public static function record_error( $error ) {
+	public static function record_error( $error ): void {
 		$error_data    = $error->get_error_data();
 		$error_details = isset( $error_data['details'] ) ? sprintf( ' - %s', ( $error_data['details'] ) ) : '';
 
@@ -45,7 +50,10 @@ class Analytics {
 		}
 	}
 
-	public static function send_analytics() {
+	/**
+	 * Send the analytics, if present. If an error is present, then usage analytics are not sent. 
+	 */
+	public static function send_analytics(): void {
 		if ( empty( self::$analytics_to_send ) ) {
 			return;
 		}
@@ -61,7 +69,12 @@ class Analytics {
 		self::send_pixel( self::$analytics_to_send );
 	}
 
-	private static function send_pixel( $stats ) {
+	/**
+	 * Send the stats to the WP Pixel endpoint.
+	 * 
+	 * @param array $stats
+	 */
+	private static function send_pixel( $stats ): void {
 		$query_args = [
 			'v' => 'wpcom-no-pv',
 		];
@@ -82,7 +95,12 @@ class Analytics {
 		) );
 	}
 
-	private static function is_wpvip_site() {
+	/**
+	 * Check if the site is a WPVIP site.
+	 * 
+	 * @return bool true if it is a WPVIP site, false otherwise
+	 */
+	private static function is_wpvip_site(): bool {
 		return defined( 'WPCOM_IS_VIP_ENV' ) && constant( 'WPCOM_IS_VIP_ENV' ) === true
 			&& defined( 'WPCOM_SANDBOXED' ) && constant( 'WPCOM_SANDBOXED' ) === false
 			&& defined( 'FILES_CLIENT_SITE_ID' );

--- a/src/analytics/analytics.php
+++ b/src/analytics/analytics.php
@@ -34,7 +34,7 @@ class Analytics {
 	/**
 	 * Record the usage of the plugin, for VIP sites only. For non-VIP sites, this is a no-op.
 	 */
-	public static function record_usage(): void {
+	public static function record_usage() {
 		// Record usage on WPVIP sites only.
 		if ( ! self::is_wpvip_site() ) {
 			return;
@@ -46,11 +46,11 @@ class Analytics {
 	/**
 	 * Record an error if it's allowed, for VIP sites only. For non-VIP sites, this is a no-op.
 	 * 
-	 * @param WP_Error $error
+	 * @param WP_Error $error the error to record.
 	 *
 	 * @return void
 	 */
-	public static function record_error( $error ): void {
+	public static function record_error( $error ) {
 		$error_data    = $error->get_error_data();
 		$error_details = isset( $error_data['details'] ) ? sprintf( ' - %s', ( $error_data['details'] ) ) : '';
 
@@ -70,7 +70,7 @@ class Analytics {
 	/**
 	 * Send the analytics, if present. If an error is present, then usage analytics are not sent. 
 	 */
-	public static function send_analytics(): void {
+	public static function send_analytics() {
 		if ( empty( self::$analytics_to_send ) ) {
 			return;
 		}
@@ -94,7 +94,7 @@ class Analytics {
 	 * 
 	 * @return bool true if it is a WPVIP site, false otherwise
 	 */
-	private static function is_wpvip_site(): bool {
+	private static function is_wpvip_site() {
 		return defined( 'WPCOM_IS_VIP_ENV' ) && constant( 'WPCOM_IS_VIP_ENV' ) === true
 			&& defined( 'WPCOM_SANDBOXED' ) && constant( 'WPCOM_SANDBOXED' ) === false
 			&& defined( 'FILES_CLIENT_SITE_ID' )

--- a/src/analytics/analytics.php
+++ b/src/analytics/analytics.php
@@ -1,8 +1,7 @@
 <?php
 /**
- * Analytics
+ * Analytics for the Block Data API.
  * 
- * @file
  * @package vip-block-data-api
  */
 

--- a/src/analytics/analytics.php
+++ b/src/analytics/analytics.php
@@ -25,6 +25,8 @@ class Analytics {
 
 	/**
 	 * Initialize the Analytics class.
+	 * 
+	 * @access private
 	 */
 	public static function init() {
 		add_action( 'shutdown', [ __CLASS__, 'send_analytics' ] );
@@ -32,6 +34,8 @@ class Analytics {
 
 	/**
 	 * Record the usage of the plugin, for VIP sites only. For non-VIP sites, this is a no-op.
+	 * 
+	 * @return void
 	 */
 	public static function record_usage() {
 		// Record usage on WPVIP sites only.
@@ -68,6 +72,8 @@ class Analytics {
 
 	/**
 	 * Send the analytics, if present. If an error is present, then usage analytics are not sent. 
+	 * 
+	 * @return void
 	 */
 	public static function send_analytics() {
 		if ( empty( self::$analytics_to_send ) ) {

--- a/src/analytics/analytics.php
+++ b/src/analytics/analytics.php
@@ -88,7 +88,7 @@ class Analytics {
 			unset( self::$analytics_to_send[ WPCOMVIP__BLOCK_DATA_API__STAT_NAME__USAGE ] );
 		}
 
-		// Use the built in mu-plugins methods to send the data to VIP Stats.
+		// Use built-in VIP mu-plugins method to send analytics to VIP Stats, if present.
 		if ( function_exists( '\Automattic\VIP\Stats\send_pixel' ) ) {
 			\Automattic\VIP\Stats\send_pixel( self::$analytics_to_send );
 		}

--- a/src/analytics/analytics.php
+++ b/src/analytics/analytics.php
@@ -49,7 +49,7 @@ class Analytics {
 	/**
 	 * Record an error if it's allowed, for VIP sites only. For non-VIP sites, this is a no-op.
 	 * 
-	 * @param WP_Error $error the error to record.
+	 * @param WP_Error $error Error to record.
 	 *
 	 * @return void
 	 */

--- a/src/parser/block-additions/core-image.php
+++ b/src/parser/block-additions/core-image.php
@@ -10,12 +10,14 @@ class CoreImage {
 	}
 
 	/**
-	 * @param array[string]array $sourced_block
-	 * @param string $block_name
-	 * @param int $post_id
-	 * @param array[string]array $block
+	 * Add size metadata to core/image blocks
+	 * 
+	 * @param array $sourced_block the sourced block result
+	 * @param string $block_name the name of the block
+	 * @param int $post_id the id of the post
+	 * @param array $block the block itself
 	 *
-	 * @return array[string]array
+	 * @return array the updated sourced block, with the new metadata information
 	 */
 	public static function add_image_metadata( $sourced_block, $block_name, $post_id, $block ) {
 		if ( 'core/image' !== $block_name ) {
@@ -40,6 +42,14 @@ class CoreImage {
 		return $sourced_block;
 	}
 
+	/**
+	 * Get the size metadata for an image block
+	 * 
+	 * @param array $attributes the attributes of the block
+	 * @param array $attachment_metadata the metadata of the attachment
+	 * 
+	 * @return array the size metadata
+	 */
 	private static function get_size_metadata( $attributes, $attachment_metadata ) {
 		$size_metadata = [];
 

--- a/src/parser/block-additions/core-image.php
+++ b/src/parser/block-additions/core-image.php
@@ -12,10 +12,10 @@ class CoreImage {
 	/**
 	 * Add size metadata to core/image blocks
 	 * 
-	 * @param array $sourced_block the sourced block result
-	 * @param string $block_name the name of the block
+	 * @param array    $sourced_block the sourced block result
+	 * @param string   $block_name the name of the block
 	 * @param int|null $post_id the id of the post
-	 * @param array $block the block itself
+	 * @param array    $block the block itself
 	 *
 	 * @return array the updated sourced block, with the new metadata information
 	 */

--- a/src/parser/block-additions/core-image.php
+++ b/src/parser/block-additions/core-image.php
@@ -2,7 +2,6 @@
 /**
  * Enhancements for the core/image block
  * 
- * @file
  * @package vip-block-data-api
  */
 

--- a/src/parser/block-additions/core-image.php
+++ b/src/parser/block-additions/core-image.php
@@ -15,6 +15,8 @@ defined( 'ABSPATH' ) || die();
 class CoreImage {
 	/**
 	 * Initialize the CoreImage class.
+	 * 
+	 * @access private
 	 */
 	public static function init() {
 		add_filter( 'vip_block_data_api__sourced_block_result', [ __CLASS__, 'add_image_metadata' ], 5, 4 );
@@ -27,6 +29,8 @@ class CoreImage {
 	 * @param string   $block_name the name of the block.
 	 * @param int|null $post_id the id of the post.
 	 * @param array    $block the block itself.
+	 * 
+	 * @access private
 	 *
 	 * @return array the updated sourced block, with the new metadata information
 	 */

--- a/src/parser/block-additions/core-image.php
+++ b/src/parser/block-additions/core-image.php
@@ -1,10 +1,22 @@
 <?php
+/**
+ * Enhancements for the core/image block
+ * 
+ * @file
+ * @package vip-block-data-api
+ */
 
 namespace WPCOMVIP\BlockDataApi\ContentParser\BlockAdditions;
 
 defined( 'ABSPATH' ) || die();
 
+/**
+ * Enhance the core/image block with attributes related to its size.
+ */
 class CoreImage {
+	/**
+	 * Initialize the CoreImage class.
+	 */
 	public static function init() {
 		add_filter( 'vip_block_data_api__sourced_block_result', [ __CLASS__, 'add_image_metadata' ], 5, 4 );
 	}
@@ -12,10 +24,10 @@ class CoreImage {
 	/**
 	 * Add size metadata to core/image blocks
 	 * 
-	 * @param array    $sourced_block the sourced block result
-	 * @param string   $block_name the name of the block
-	 * @param int|null $post_id the id of the post
-	 * @param array    $block the block itself
+	 * @param array    $sourced_block the sourced block result.
+	 * @param string   $block_name the name of the block.
+	 * @param int|null $post_id the id of the post.
+	 * @param array    $block the block itself.
 	 *
 	 * @return array the updated sourced block, with the new metadata information
 	 */
@@ -45,8 +57,8 @@ class CoreImage {
 	/**
 	 * Get the size metadata for an image block
 	 * 
-	 * @param array $attributes the attributes of the block
-	 * @param array $attachment_metadata the metadata of the attachment
+	 * @param array $attributes the attributes of the block.
+	 * @param array $attachment_metadata the metadata of the attachment.
 	 * 
 	 * @return array the size metadata
 	 */
@@ -61,7 +73,7 @@ class CoreImage {
 			$size_metadata['height'] = $attachment_metadata['height'];
 		}
 
-		// If the attached image uses a thumbnail size, find the altered width and height
+		// If the attached image uses a thumbnail size, find the altered width and height.
 		$size_slug = $attributes['sizeSlug'] ?? null;
 
 		if ( null !== $size_slug && isset( $attachment_metadata['sizes'][ $size_slug ] ) ) {

--- a/src/parser/block-additions/core-image.php
+++ b/src/parser/block-additions/core-image.php
@@ -32,7 +32,7 @@ class CoreImage {
 	 * 
 	 * @access private
 	 *
-	 * @return array the updated sourced block, with the new metadata information
+	 * @return array Updated sourced block with new metadata information
 	 */
 	public static function add_image_metadata( $sourced_block, $block_name, $post_id, $block ) {
 		if ( 'core/image' !== $block_name ) {

--- a/src/parser/block-additions/core-image.php
+++ b/src/parser/block-additions/core-image.php
@@ -31,7 +31,7 @@ class CoreImage {
 	 *
 	 * @return array the updated sourced block, with the new metadata information
 	 */
-	public static function add_image_metadata( array $sourced_block, string $block_name, ?int $post_id, ?array $block ): array {
+	public static function add_image_metadata( $sourced_block, $block_name, $post_id, $block ) {
 		if ( 'core/image' !== $block_name ) {
 			return $sourced_block;
 		}
@@ -62,7 +62,7 @@ class CoreImage {
 	 * 
 	 * @return array the size metadata
 	 */
-	private static function get_size_metadata( array $attributes, array $attachment_metadata ): array {
+	private static function get_size_metadata( $attributes, $attachment_metadata ) {
 		$size_metadata = [];
 
 		if ( isset( $attachment_metadata['width'] ) ) {

--- a/src/parser/block-additions/core-image.php
+++ b/src/parser/block-additions/core-image.php
@@ -25,10 +25,10 @@ class CoreImage {
 	/**
 	 * Add size metadata to core/image blocks
 	 * 
-	 * @param array    $sourced_block the sourced block result.
-	 * @param string   $block_name the name of the block.
-	 * @param int|null $post_id the id of the post.
-	 * @param array    $block the block itself.
+	 * @param array    $sourced_block Sourced block result.
+	 * @param string   $block_name Name of the block.
+	 * @param int|null $post_id Id of the post.
+	 * @param array    $block Block being parsed.
 	 * 
 	 * @access private
 	 *
@@ -60,8 +60,8 @@ class CoreImage {
 	/**
 	 * Get the size metadata for an image block
 	 * 
-	 * @param array $attributes the attributes of the block.
-	 * @param array $attachment_metadata the metadata of the attachment.
+	 * @param array $attributes Attributes of the block.
+	 * @param array $attachment_metadata Metadata of the attachment.
 	 * 
 	 * @return array the size metadata
 	 */

--- a/src/parser/block-additions/core-image.php
+++ b/src/parser/block-additions/core-image.php
@@ -14,12 +14,12 @@ class CoreImage {
 	 * 
 	 * @param array $sourced_block the sourced block result
 	 * @param string $block_name the name of the block
-	 * @param int $post_id the id of the post
+	 * @param int|null $post_id the id of the post
 	 * @param array $block the block itself
 	 *
 	 * @return array the updated sourced block, with the new metadata information
 	 */
-	public static function add_image_metadata( $sourced_block, $block_name, $post_id, $block ) {
+	public static function add_image_metadata( array $sourced_block, string $block_name, ?int $post_id, ?array $block ): array {
 		if ( 'core/image' !== $block_name ) {
 			return $sourced_block;
 		}
@@ -50,7 +50,7 @@ class CoreImage {
 	 * 
 	 * @return array the size metadata
 	 */
-	private static function get_size_metadata( $attributes, $attachment_metadata ) {
+	private static function get_size_metadata( array $attributes, array $attachment_metadata ): array {
 		$size_metadata = [];
 
 		if ( isset( $attachment_metadata['width'] ) ) {

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -20,7 +20,7 @@ use Symfony\Component\DomCrawler\Crawler;
  */
 class ContentParser {
 	/**
-	 * The Block registry instance
+	 * Block registry instance
 	 *
 	 * @var WP_Block_Type_Registry
 	 * 
@@ -28,7 +28,7 @@ class ContentParser {
 	 */
 	protected $block_registry;
 	/**
-	 * The post ID
+	 * Post ID
 	 * 
 	 * @var int
 	 * 
@@ -36,7 +36,7 @@ class ContentParser {
 	 */
 	protected $post_id;
 	/**
-	 * The warnings that would be returned with the blocks
+	 * Warnings that would be returned with the blocks
 	 * 
 	 * @var array
 	 * 
@@ -60,14 +60,14 @@ class ContentParser {
 	/**
 	 * Filter out a block from the blocks output based on:
 	 * 
-	 * - The include parameter, if it is set or 
-	 * - The exclude parameter, if it is set.
+	 * - include parameter, if it is set or 
+	 * - exclude parameter, if it is set.
 	 * 
 	 * and finally, based on a filter vip_block_data_api__allow_block
 	 * 
-	 * @param array  $block the current block.
-	 * @param string $block_name the name of the block.
-	 * @param array  $filter_options the filter options, if any.
+	 * @param array  $block Current block.
+	 * @param string $block_name Name of the block.
+	 * @param array  $filter_options Options to be used for filtering, if any.
 	 * 
 	 * @return bool true, if the block should be included or false otherwise
 	 */
@@ -84,8 +84,8 @@ class ContentParser {
 		 * Filter out blocks from the blocks output
 		 *
 		 * @param bool   $is_block_included True if the block should be included, or false to filter it out.
-		 * @param string $block_name    The name of the parsed block, e.g. 'core/paragraph'.
-		 * @param string $block         The result of parse_blocks() for this block.
+		 * @param string $block_name   Name of the parsed block, e.g. 'core/paragraph'.
+		 * @param string $block         Result of parse_blocks() for this block.
 		 *                              Contains 'blockName', 'attrs', 'innerHTML', and 'innerBlocks' keys.
 		 */
 		return apply_filters( 'vip_block_data_api__allow_block', $is_block_included, $block_name, $block );
@@ -171,9 +171,9 @@ class ContentParser {
 	/**
 	 * Processes a single block, and returns the sourced block data.
 	 * 
-	 * @param array           $block the block to be processed.
-	 * @param WP_Block_Type[] $registered_blocks the registered blocks.
-	 * @param array           $filter_options the filter options, if any.
+	 * @param array           $block Block to be processed.
+	 * @param WP_Block_Type[] $registered_blocks Blocks that have been registered.
+	 * @param array           $filter_options Options to filter using, if any.
 	 *
 	 * @return array|null
 	 */
@@ -253,9 +253,9 @@ class ContentParser {
 		 * Filters a block when parsing is complete.
 		 *
 		 * @param array $sourced_block An associative array of parsed block data with keys 'name' and 'attribute'.
-		 * @param string $block_name The name of the parsed block, e.g. 'core/paragraph'.
-		 * @param int $post_id The post ID associated with the parsed block.
-		 * @param array $block The result of parse_blocks() for this block. Contains 'blockName', 'attrs', 'innerHTML', and 'innerBlocks' keys.
+		 * @param string $block_name Name of the parsed block, e.g. 'core/paragraph'.
+		 * @param int $post_id Post ID associated with the parsed block.
+		 * @param array $block Result of parse_blocks() for this block. Contains 'blockName', 'attrs', 'innerHTML', and 'innerBlocks' keys.
 		 */
 		$sourced_block = apply_filters( 'vip_block_data_api__sourced_block_result', $sourced_block, $block_name, $this->post_id, $block );
 
@@ -270,8 +270,8 @@ class ContentParser {
 	/**
 	 * Processes the source attributes of a block.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
-	 * @param array                                $block_attribute_definition the definition of the block attribute.
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler Crawler instance.
+	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 * 
 	 *  @return array|string|null
 	 */
@@ -315,8 +315,8 @@ class ContentParser {
 	/**
 	 * Helper function to process the `attribute` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
-	 * @param array                                $block_attribute_definition the definition of the block attribute.
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler Crawler instance.
+	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
@@ -342,8 +342,8 @@ class ContentParser {
 	/**
 	 * Helper function to process the `html` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
-	 * @param array                                $block_attribute_definition the definition of the block attribute.
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler Crawler instance.
+	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
@@ -378,8 +378,8 @@ class ContentParser {
 	/**
 	 * Helper function to process the `text` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
-	 * @param array                                $block_attribute_definition the definition of the block attribute.
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler Crawler instance.
+	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
@@ -404,8 +404,8 @@ class ContentParser {
 	/**
 	 * Helper function to process the `query` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
-	 * @param array                                $block_attribute_definition the definition of the block attribute.
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler Crawler instance.
+	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
@@ -440,8 +440,8 @@ class ContentParser {
 	/**
 	 * Helper function to process the `tag` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
-	 * @param array                                $block_attribute_definition the definition of the block attribute.
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler Crawler instance.
+	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
@@ -468,7 +468,7 @@ class ContentParser {
 	/**
 	 * Helper function to process the `raw` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler Crawler instance.
 	 *
 	 * @return string|null
 	 */
@@ -490,7 +490,7 @@ class ContentParser {
 	/**
 	 * Helper function to process the `meta` source attribute.
 	 * 
-	 * @param array $block_attribute_definition the definition of the block attribute.
+	 * @param array $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
@@ -516,8 +516,8 @@ class ContentParser {
 	/**
 	 * Helper function to process the `children` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
-	 * @param array                                $block_attribute_definition the definition of the block attribute.
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler Crawler instance.
+	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return array|string|null
 	 */
@@ -566,8 +566,8 @@ class ContentParser {
 	/**
 	 * Helper function to process the `node` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
-	 * @param array                                $block_attribute_definition the definition of the block attribute.
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler Crawler instance.
+	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
@@ -602,7 +602,7 @@ class ContentParser {
 	 * Helper function to process markup used by the deprecated 'node' and 'children' sources.
 	 * These sources can return a representation of the DOM tree and bypass the $crawler to access DOMNodes directly.
 	 *
-	 * @param \DOMNode $node the node currently being processed.
+	 * @param \DOMNode $node Node currently being processed.
 	 *
 	 * @return array|string|null
 	 */
@@ -635,7 +635,7 @@ class ContentParser {
 	/**
 	 * Add a warning to the warnings, if a block is not registered server-side.
 	 * 
-	 * @param string $block_name the name of the block.
+	 * @param string $block_name Name of the block.
 	 * 
 	 * @return void
 	 */

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -66,7 +66,7 @@ class ContentParser {
 	 * 
 	 * @return bool true, if the block should be included or false otherwise
 	 */
-	public function should_block_be_included( array $block, string $block_name, array $filter_options ): bool {
+	public function should_block_be_included( $block, $block_name, $filter_options ) {
 		$is_block_included = true;
 
 		if ( ! empty( $filter_options['include'] ) ) {
@@ -97,7 +97,7 @@ class ContentParser {
 	 *
 	 * @return array|WP_Error
 	 */
-	public function parse( string $post_content, ?int $post_id = null, array $filter_options = [] ) {
+	public function parse( $post_content, $post_id = null, $filter_options = [] ) {
 		if ( isset( $filter_options['exclude'] ) && isset( $filter_options['include'] ) ) {
 			return new WP_Error( 'vip-block-data-api-invalid-params', 'Cannot provide blocks to exclude and include at the same time', [ 'status' => 400 ] );
 		}
@@ -166,12 +166,13 @@ class ContentParser {
 	/**
 	 * Processes a single block, and returns the sourced block data.
 	 * 
-	 * @param array           $block
-	 * @param WP_Block_Type[] $registered_blocks
+	 * @param array           $block the block to be processed.
+	 * @param WP_Block_Type[] $registered_blocks the registered blocks.
+	 * @param array           $filter_options the filter options, if any.
 	 *
 	 * @return array|null
 	 */
-	protected function source_block( array $block, $registered_blocks, mixed $filter_options ): array | null {
+	protected function source_block( $block, $registered_blocks, $filter_options ) {
 		$block_name = $block['blockName'];
 
 		if ( ! $this->should_block_be_included( $block, $block_name, $filter_options ) ) {
@@ -192,25 +193,25 @@ class ContentParser {
 			$attribute_default_value = $block_attribute_definition['default'] ?? null;
 
 			if ( null === $attribute_source ) {
-				// Unsourced attributes are stored in the block's delimiter attributes, skip DOM parser
+				// Unsourced attributes are stored in the block's delimiter attributes, skip DOM parser.
 
 				if ( isset( $block_attributes[ $block_attribute_name ] ) ) {
-					// Attribute is already set in the block's delimiter attributes, skip
+					// Attribute is already set in the block's delimiter attributes, skip.
 					continue;
 				} elseif ( null !== $attribute_default_value ) {
-					// Attribute is unset and has a default value, use default value
+					// Attribute is unset and has a default value, use default value.
 					$block_attributes[ $block_attribute_name ] = $attribute_default_value;
 					continue;
 				} else {
-					// Attribute is unset and has no default value, skip
+					// Attribute is unset and has no default value, skip.
 					continue;
 				}
 			}
 
-			// Specify a manual doctype so that the parser will use the HTML5 parser
+			// Specify a manual doctype so that the parser will use the HTML5 parser.
 			$crawler = new Crawler( sprintf( '<!doctype html><html><body>%s</body></html>', $block['innerHTML'] ) );
 
-			// Enter the <body> tag for block parsing
+			// Enter the <body> tag for block parsing.
 			$crawler = $crawler->filter( 'body' );
 
 			$attribute_value = $this->source_attribute( $crawler, $block_attribute_definition );
@@ -253,7 +254,7 @@ class ContentParser {
 		 */
 		$sourced_block = apply_filters( 'vip_block_data_api__sourced_block_result', $sourced_block, $block_name, $this->post_id, $block );
 
-		// If attributes are empty, explicitly use an object to avoid encoding an empty array in JSON
+		// If attributes are empty, explicitly use an object to avoid encoding an empty array in JSON.
 		if ( empty( $sourced_block['attributes'] ) ) {
 			$sourced_block['attributes'] = (object) [];
 		}
@@ -264,21 +265,21 @@ class ContentParser {
 	/**
 	 * Processes the source attributes of a block.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array                                $block_attribute_definition
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
+	 * @param array                                $block_attribute_definition the definition of the block attribute.
 	 * 
 	 *  @return array|string|null
 	 */
-	protected function source_attribute( $crawler, array $block_attribute_definition ): array|string|null {
+	protected function source_attribute( $crawler, $block_attribute_definition ) {
 		$attribute_value         = null;
 		$attribute_default_value = $block_attribute_definition['default'] ?? null;
 		$attribute_source        = $block_attribute_definition['source'];
 
 		// See block attribute sources:
-		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source
+		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source.
 		if ( 'attribute' === $attribute_source || 'property' === $attribute_source ) {
 			// 'property' sources were removed in 2018. Default to attribute value.
-			// https://github.com/WordPress/gutenberg/pull/8276
+			// https://github.com/WordPress/gutenberg/pull/8276.
 
 			$attribute_value = $this->source_block_attribute( $crawler, $block_attribute_definition );
 		} elseif ( 'html' === $attribute_source ) {
@@ -309,14 +310,14 @@ class ContentParser {
 	/**
 	 * Helper function to process the `attribute` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array                                $block_attribute_definition
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
+	 * @param array                                $block_attribute_definition the definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_attribute( $crawler, array $block_attribute_definition ): array|string|null {
+	protected function source_block_attribute( $crawler, $block_attribute_definition ) {
 		// 'attribute' sources:
-		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#attribute-source
+		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#attribute-source.
 
 		$attribute_value = null;
 		$attribute       = $block_attribute_definition['attribute'];
@@ -336,14 +337,14 @@ class ContentParser {
 	/**
 	 * Helper function to process the `html` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array                                $block_attribute_definition
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
+	 * @param array                                $block_attribute_definition the definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_html( $crawler, array $block_attribute_definition ): array|string|null {
+	protected function source_block_html( $crawler, $block_attribute_definition ) {
 		// 'html' sources:
-		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#html-source
+		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#html-source.
 
 		$attribute_value = null;
 		$selector        = $block_attribute_definition['selector'] ?? null;
@@ -372,14 +373,14 @@ class ContentParser {
 	/**
 	 * Helper function to process the `text` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array                                $block_attribute_definition
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
+	 * @param array                                $block_attribute_definition the definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_text( $crawler, array $block_attribute_definition ): array|string|null {
+	protected function source_block_text( $crawler, $block_attribute_definition ) {
 		// 'text' sources:
-		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#text-source
+		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#text-source.
 
 		$attribute_value = null;
 		$selector        = $block_attribute_definition['selector'] ?? null;
@@ -398,14 +399,14 @@ class ContentParser {
 	/**
 	 * Helper function to process the `query` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array                                $block_attribute_definition
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
+	 * @param array                                $block_attribute_definition the definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_query( $crawler, array $block_attribute_definition ): array|string|null {
+	protected function source_block_query( $crawler, $block_attribute_definition ) {
 		// 'query' sources:
-		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#query-source
+		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#query-source.
 
 		$query_items = $block_attribute_definition['query'];
 		$selector    = $block_attribute_definition['selector'] ?? null;
@@ -419,7 +420,7 @@ class ContentParser {
 				return $this->source_attribute( $node, $query_item );
 			}, $query_items);
 
-			// Remove unsourced query values
+			// Remove unsourced query values.
 			$attribute_value = array_filter( $attribute_value, function( $value ) {
 				return null !== $value;
 			});
@@ -434,16 +435,16 @@ class ContentParser {
 	/**
 	 * Helper function to process the `tag` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array                                $block_attribute_definition
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
+	 * @param array                                $block_attribute_definition the definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_tag( $crawler, array $block_attribute_definition ): array|string|null {
+	protected function source_block_tag( $crawler, $block_attribute_definition ) {
 		// The only current usage of the 'tag' attribute is Gutenberg core is the 'core/table' block:
-		// https://github.com/WordPress/gutenberg/blob/796b800/packages/block-library/src/table/block.json#L39
+		// https://github.com/WordPress/gutenberg/blob/796b800/packages/block-library/src/table/block.json#L39.
 		// Also see tag attribute parsing in Gutenberg:
-		// https://github.com/WordPress/gutenberg/blob/6517008/packages/blocks/src/api/parser/get-block-attributes.js#L225
+		// https://github.com/WordPress/gutenberg/blob/6517008/packages/blocks/src/api/parser/get-block-attributes.js#L225.
 
 		$attribute_value = null;
 		$selector        = $block_attribute_definition['selector'] ?? null;
@@ -462,16 +463,15 @@ class ContentParser {
 	/**
 	 * Helper function to process the `raw` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array                                $block_attribute_definition
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_raw( $crawler ): array|string|null {
+	protected function source_block_raw( $crawler ) {
 		// The only current usage of the 'raw' attribute in Gutenberg core is the 'core/html' block:
-		// https://github.com/WordPress/gutenberg/blob/6517008/packages/block-library/src/html/block.json#L13
+		// https://github.com/WordPress/gutenberg/blob/6517008/packages/block-library/src/html/block.json#L13.
 		// Also see tag attribute parsing in Gutenberg:
-		// https://github.com/WordPress/gutenberg/blob/6517008/packages/blocks/src/api/parser/get-block-attributes.js#L131
+		// https://github.com/WordPress/gutenberg/blob/6517008/packages/blocks/src/api/parser/get-block-attributes.js#L131.
 
 		$attribute_value = null;
 
@@ -485,13 +485,13 @@ class ContentParser {
 	/**
 	 * Helper function to process the `meta` source attribute.
 	 * 
-	 * @param array $block_attribute_definition
+	 * @param array $block_attribute_definition the definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_meta( array $block_attribute_definition ): array|string|null {
+	protected function source_block_meta( $block_attribute_definition ) {
 		// 'meta' sources:
-		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#meta-source
+		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#meta-source.
 
 		$post = get_post( $this->post_id );
 		if ( null === $post ) {
@@ -511,16 +511,16 @@ class ContentParser {
 	/**
 	 * Helper function to process the `children` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array                                $block_attribute_definition
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
+	 * @param array                                $block_attribute_definition the definition of the block attribute.
 	 *
 	 * @return array|string|null
 	 */
-	protected function source_block_children( $crawler, array $block_attribute_definition ): array|string|null {
+	protected function source_block_children( $crawler, $block_attribute_definition ) {
 		// 'children' attribute usage was removed from core in 2018, but not officically deprecated until WordPress 6.1:
-		// https://github.com/WordPress/gutenberg/pull/44265
+		// https://github.com/WordPress/gutenberg/pull/44265.
 		// Parsing code for 'children' sources can be found here:
-		// https://github.com/WordPress/gutenberg/blob/dd0504b/packages/blocks/src/api/children.js#L149
+		// https://github.com/WordPress/gutenberg/blob/dd0504b/packages/blocks/src/api/children.js#L149.
 
 		$attribute_values = [];
 		$selector         = $block_attribute_definition['selector'] ?? null;
@@ -530,7 +530,7 @@ class ContentParser {
 		}
 
 		if ( $crawler->count() === 0 ) {
-			// If the selector doesn't exist, return a default empty array
+			// If the selector doesn't exist, return a default empty array.
 			return $attribute_values;
 		}
 
@@ -561,16 +561,16 @@ class ContentParser {
 	/**
 	 * Helper function to process the `node` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array                                $block_attribute_definition
+	 * @param Symfony\Component\DomCrawler\Crawler $crawler the crawler instance.
+	 * @param array                                $block_attribute_definition the definition of the block attribute.
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_node( $crawler, array $block_attribute_definition ): array|string|null {
+	protected function source_block_node( $crawler, $block_attribute_definition ) {
 		// 'node' attribute usage was removed from core in 2018, but not officically deprecated until WordPress 6.1:
-		// https://github.com/WordPress/gutenberg/pull/44265
+		// https://github.com/WordPress/gutenberg/pull/44265.
 		// Parsing code for 'node' sources can be found here:
-		// https://github.com/WordPress/gutenberg/blob/dd0504bd34c29b5b2824d82c8d2bb3a8d0f071ec/packages/blocks/src/api/node.js#L125
+		// https://github.com/WordPress/gutenberg/blob/dd0504bd34c29b5b2824d82c8d2bb3a8d0f071ec/packages/blocks/src/api/node.js#L125.
 
 		$attribute_value = null;
 		$selector        = $block_attribute_definition['selector'] ?? null;
@@ -597,7 +597,7 @@ class ContentParser {
 	 * Helper function to process markup used by the deprecated 'node' and 'children' sources.
 	 * These sources can return a representation of the DOM tree and bypass the $crawler to access DOMNodes directly.
 	 *
-	 * @param \DOMNode $node
+	 * @param \DOMNode $node the node currently being processed.
 	 *
 	 * @return array|string|null
 	 */
@@ -605,17 +605,17 @@ class ContentParser {
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- external API calls
 
 		if ( XML_TEXT_NODE === $node->nodeType ) {
-			// For plain text nodes, return the text directly
+			// For plain text nodes, return the text directly.
 			$text = trim( $node->nodeValue );
 
-			// Exclude whitespace-only nodes
+			// Exclude whitespace-only nodes.
 			if ( ! empty( $text ) ) {
 				return $text;
 			}
 		} elseif ( XML_ELEMENT_NODE === $node->nodeType ) {
 			$children = array_map( [ $this, 'from_dom_node' ], iterator_to_array( $node->childNodes ) );
 
-			// For element nodes, recurse and return an array of child nodes
+			// For element nodes, recurse and return an array of child nodes.
 			return [
 				'type'     => $node->nodeName,
 				'children' => array_filter( $children ),
@@ -630,9 +630,9 @@ class ContentParser {
 	/**
 	 * Add a warning to the warnings, if a block is not registered server-side.
 	 * 
-	 * @param string $block_name the name of the block
+	 * @param string $block_name the name of the block.
 	 */
-	protected function add_missing_block_warning( string $block_name ): void {
+	protected function add_missing_block_warning( $block_name ) {
 		$warning_message = sprintf( 'Block type "%s" is not server-side registered. Sourced block attributes will not be available.', $block_name );
 
 		if ( ! in_array( $warning_message, $this->warnings ) ) {
@@ -645,7 +645,7 @@ class ContentParser {
 	 * 
 	 * @return bool true if debug is enabled, or false otherwise
 	 */
-	protected function is_debug_enabled(): bool {
+	protected function is_debug_enabled() {
 		return defined( 'VIP_BLOCK_DATA_API__PARSE_DEBUG' ) && constant( 'VIP_BLOCK_DATA_API__PARSE_DEBUG' ) === true;
 	}
 }

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -23,18 +23,24 @@ class ContentParser {
 	 * The Block registry instance
 	 *
 	 * @var WP_Block_Type_Registry
+	 * 
+	 * @access private
 	 */
 	protected $block_registry;
 	/**
 	 * The post ID
 	 * 
 	 * @var int
+	 * 
+	 * @access private
 	 */
 	protected $post_id;
 	/**
 	 * The warnings that would be returned with the blocks
 	 * 
 	 * @var array
+	 * 
+	 * @access private
 	 */
 	protected $warnings = [];
 
@@ -630,6 +636,8 @@ class ContentParser {
 	 * Add a warning to the warnings, if a block is not registered server-side.
 	 * 
 	 * @param string $block_name the name of the block.
+	 * 
+	 * @return void
 	 */
 	protected function add_missing_block_warning( $block_name ) {
 		$warning_message = sprintf( 'Block type "%s" is not server-side registered. Sourced block attributes will not be available.', $block_name );

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -402,12 +402,14 @@ class ContentParser {
 	}
 
 	/**
+	 * Helper function to process the `raw` source attribute.
+	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
 	 * @param array $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_raw( $crawler, $block_attribute_definition ) {
+	protected function source_block_raw( $crawler, $block_attribute_definition ): string|null {
 		// The only current usage of the 'raw' attribute in Gutenberg core is the 'core/html' block:
 		// https://github.com/WordPress/gutenberg/blob/6517008/packages/block-library/src/html/block.json#L13
 		// Also see tag attribute parsing in Gutenberg:
@@ -423,12 +425,14 @@ class ContentParser {
 	}
 
 	/**
+	 * Helper function to process the `meta` source attribute.
+	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
 	 * @param array $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_meta( $block_attribute_definition ) {
+	protected function source_block_meta( $block_attribute_definition ): string|null {
 		// 'meta' sources:
 		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#meta-source
 
@@ -448,12 +452,14 @@ class ContentParser {
 	}
 
 	/**
+	 * Helper function to process the `children` source attribute.
+	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
 	 * @param array $block_attribute_definition
 	 *
-	 * @return string|null
+	 * @return array|string|null
 	 */
-	protected function source_block_children( $crawler, $block_attribute_definition ) {
+	protected function source_block_children( $crawler, $block_attribute_definition ): array|string|null {
 		// 'children' attribute usage was removed from core in 2018, but not officically deprecated until WordPress 6.1:
 		// https://github.com/WordPress/gutenberg/pull/44265
 		// Parsing code for 'children' sources can be found here:
@@ -496,12 +502,14 @@ class ContentParser {
 	}
 
 	/**
+	 * Helper function to process the `node` source attribute.
+	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
 	 * @param array $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_node( $crawler, $block_attribute_definition ) {
+	protected function source_block_node( $crawler, $block_attribute_definition ): string|null {
 		// 'node' attribute usage was removed from core in 2018, but not officically deprecated until WordPress 6.1:
 		// https://github.com/WordPress/gutenberg/pull/44265
 		// Parsing code for 'node' sources can be found here:
@@ -536,7 +544,7 @@ class ContentParser {
 	 *
 	 * @return array|string|null
 	 */
-	protected function from_dom_node( $node ) {
+	protected function from_dom_node( $node ): array|string|null {
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- external API calls
 
 		if ( XML_TEXT_NODE === $node->nodeType ) {
@@ -562,7 +570,12 @@ class ContentParser {
 		// phpcs:enable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	}
 
-	protected function add_missing_block_warning( $block_name ) {
+	/**
+	 * Add a warning to the warnings, if a block is not registered server-side.
+	 * 
+	 * @param string $block_name the name of the block
+	 */
+	protected function add_missing_block_warning( $block_name ): void {
 		$warning_message = sprintf( 'Block type "%s" is not server-side registered. Sourced block attributes will not be available.', $block_name );
 
 		if ( ! in_array( $warning_message, $this->warnings ) ) {
@@ -570,7 +583,12 @@ class ContentParser {
 		}
 	}
 
-	protected function is_debug_enabled() {
+	/**
+	 * Check if debug mode is enabled.
+	 * 
+	 * @return bool true if debug is enabled, or false otherwise
+	 */
+	protected function is_debug_enabled(): bool {
 		return defined( 'VIP_BLOCK_DATA_API__PARSE_DEBUG' ) && constant( 'VIP_BLOCK_DATA_API__PARSE_DEBUG' ) === true;
 	}
 }

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Content Parser
+ * 
+ * @file
+ * @package vip-block-data-api
+ */
 
 namespace WPCOMVIP\BlockDataApi;
 
@@ -10,13 +16,33 @@ use WP_Block_Type;
 use WP_Block_Type_Registry;
 use Symfony\Component\DomCrawler\Crawler;
 
+/**
+ * The content parser that would be used to transform a post into an array of blocks, along with their attributes.
+ */
 class ContentParser {
+	/**
+	 * The Block registry instance
+	 *
+	 * @var WP_Block_Type_Registry
+	 */
 	protected $block_registry;
+	/**
+	 * The post ID
+	 * 
+	 * @var int
+	 */
 	protected $post_id;
+	/**
+	 * The warnings that would be returned with the blocks
+	 * 
+	 * @var array
+	 */
 	protected $warnings = [];
 
 	/**
-	 * @param WP_Block_Type_Registry|null $block_registry
+	 * Initialize the ContentParser class.
+	 *
+	 * @param WP_Block_Type_Registry|null $block_registry the block registry instance.
 	 */
 	public function __construct( $block_registry = null ) {
 		if ( null === $block_registry ) {
@@ -34,9 +60,9 @@ class ContentParser {
 	 * 
 	 * and finally, based on a filter vip_block_data_api__allow_block
 	 * 
-	 * @param array  $block
-	 * @param string $block_name
-	 * @param array  $filter_options
+	 * @param array  $block the current block.
+	 * @param string $block_name the name of the block.
+	 * @param array  $filter_options the filter options, if any.
 	 * 
 	 * @return bool true, if the block should be included or false otherwise
 	 */
@@ -115,7 +141,7 @@ class ContentParser {
 				$result['warnings'] = $this->warnings;
 			}
 
-			// Debug output
+			// Debug output.
 			if ( $this->is_debug_enabled() ) {
 				$result['debug'] = [
 					'blocks_parsed' => $blocks,

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -26,7 +26,21 @@ class ContentParser {
 		$this->block_registry = $block_registry;
 	}
 
-	public function should_block_be_included( $block, $block_name, $filter_options ) {
+	/**
+	 * Filter out a block from the blocks output based on:
+	 * 
+	 * - The include parameter, if it is set or 
+	 * - The exclude parameter, if it is set.
+	 * 
+	 * and finally, based on a filter vip_block_data_api__allow_block
+	 * 
+	 * @param array $block
+	 * @param string $block_name
+	 * @param array $filter_options
+	 * 
+	 * @return bool true, if the block should be included or false otherwise
+	 */
+	public function should_block_be_included( array $block, string $block_name, mixed $filter_options ): bool {
 		$is_block_included = true;
 
 		if ( ! empty( $filter_options['include'] ) ) {
@@ -47,6 +61,8 @@ class ContentParser {
 	}
 
 	/**
+	 * Parses a post's content and returns an array of blocks with their attributes and inner blocks.
+	 * 
 	 * @param string $post_content HTML content of a post.
 	 * @param int|null $post_id ID of the post being parsed. Required for blocks containing meta-sourced attributes and some block filters.
 	 * @param array $filter_options An associative array of options for filtering blocks. Can contain keys:
@@ -55,7 +71,7 @@ class ContentParser {
 	 *
 	 * @return array|WP_Error
 	 */
-	public function parse( $post_content, $post_id = null, $filter_options = [] ) {
+	public function parse( string $post_content, ?int $post_id = null, array $filter_options = [] ) {
 		if ( isset( $filter_options['exclude'] ) && isset( $filter_options['include'] ) ) {
 			return new WP_Error( 'vip-block-data-api-invalid-params', 'Cannot provide blocks to exclude and include at the same time', [ 'status' => 400 ] );
 		}
@@ -122,12 +138,14 @@ class ContentParser {
 	}
 
 	/**
-	 * @param array[string]array $block
+	 * Processes a single block, and returns the sourced block data.
+	 * 
+	 * @param array $block
 	 * @param WP_Block_Type[] $registered_blocks
 	 *
-	 * @return array[string]array|null
+	 * @return array|null
 	 */
-	protected function source_block( $block, $registered_blocks, $filter_options ) {
+	protected function source_block( array $block, $registered_blocks, mixed $filter_options ): array | null {
 		$block_name = $block['blockName'];
 
 		if ( ! $this->should_block_be_included( $block, $block_name, $filter_options ) ) {
@@ -218,10 +236,14 @@ class ContentParser {
 	}
 
 	/**
+	 * Processes the source attributes of a block.
+	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
 	 * @param array $block_attribute_definition
+	 * 
+	 *  @return array|string|null
 	 */
-	protected function source_attribute( $crawler, $block_attribute_definition ) {
+	protected function source_attribute( $crawler, array $block_attribute_definition ): array|string|null {
 		$attribute_value         = null;
 		$attribute_default_value = $block_attribute_definition['default'] ?? null;
 		$attribute_source        = $block_attribute_definition['source'];
@@ -240,7 +262,7 @@ class ContentParser {
 		} elseif ( 'tag' === $attribute_source ) {
 			$attribute_value = $this->source_block_tag( $crawler, $block_attribute_definition );
 		} elseif ( 'raw' === $attribute_source ) {
-			$attribute_value = $this->source_block_raw( $crawler, $block_attribute_definition );
+			$attribute_value = $this->source_block_raw( $crawler );
 		} elseif ( 'query' === $attribute_source ) {
 			$attribute_value = $this->source_block_query( $crawler, $block_attribute_definition );
 		} elseif ( 'meta' === $attribute_source ) {
@@ -259,12 +281,14 @@ class ContentParser {
 	}
 
 	/**
+	 * Helper function to process the `attribute` source attribute.
+	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
 	 * @param array $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_attribute( $crawler, $block_attribute_definition ) {
+	protected function source_block_attribute( $crawler, array $block_attribute_definition ): array|string|null {
 		// 'attribute' sources:
 		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#attribute-source
 
@@ -284,12 +308,14 @@ class ContentParser {
 	}
 
 	/**
+	 * Helper function to process the `html` source attribute.
+	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
 	 * @param array $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_html( $crawler, $block_attribute_definition ) {
+	protected function source_block_html( $crawler, array $block_attribute_definition ): array|string|null {
 		// 'html' sources:
 		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#html-source
 
@@ -318,12 +344,14 @@ class ContentParser {
 	}
 
 	/**
+	 * Helper function to process the `text` source attribute.
+	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
 	 * @param array $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_text( $crawler, $block_attribute_definition ) {
+	protected function source_block_text( $crawler, array $block_attribute_definition ): array|string|null {
 		// 'text' sources:
 		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#text-source
 
@@ -342,12 +370,14 @@ class ContentParser {
 	}
 
 	/**
+	 * Helper function to process the `query` source attribute.
+	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
 	 * @param array $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_query( $crawler, $block_attribute_definition ) {
+	protected function source_block_query( $crawler, array $block_attribute_definition ): array|string|null {
 		// 'query' sources:
 		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#query-source
 
@@ -376,12 +406,14 @@ class ContentParser {
 	}
 
 	/**
+	 * Helper function to process the `tag` source attribute.
+	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
 	 * @param array $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_tag( $crawler, $block_attribute_definition ) {
+	protected function source_block_tag( $crawler, array $block_attribute_definition ): array|string|null {
 		// The only current usage of the 'tag' attribute is Gutenberg core is the 'core/table' block:
 		// https://github.com/WordPress/gutenberg/blob/796b800/packages/block-library/src/table/block.json#L39
 		// Also see tag attribute parsing in Gutenberg:
@@ -409,7 +441,7 @@ class ContentParser {
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_raw( $crawler, $block_attribute_definition ): string|null {
+	protected function source_block_raw( $crawler ): array|string|null {
 		// The only current usage of the 'raw' attribute in Gutenberg core is the 'core/html' block:
 		// https://github.com/WordPress/gutenberg/blob/6517008/packages/block-library/src/html/block.json#L13
 		// Also see tag attribute parsing in Gutenberg:
@@ -427,12 +459,11 @@ class ContentParser {
 	/**
 	 * Helper function to process the `meta` source attribute.
 	 * 
-	 * @param Symfony\Component\DomCrawler\Crawler $crawler
 	 * @param array $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_meta( $block_attribute_definition ): string|null {
+	protected function source_block_meta( array $block_attribute_definition ): array|string|null {
 		// 'meta' sources:
 		// https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#meta-source
 
@@ -459,7 +490,7 @@ class ContentParser {
 	 *
 	 * @return array|string|null
 	 */
-	protected function source_block_children( $crawler, $block_attribute_definition ): array|string|null {
+	protected function source_block_children( $crawler, array $block_attribute_definition ): array|string|null {
 		// 'children' attribute usage was removed from core in 2018, but not officically deprecated until WordPress 6.1:
 		// https://github.com/WordPress/gutenberg/pull/44265
 		// Parsing code for 'children' sources can be found here:
@@ -509,7 +540,7 @@ class ContentParser {
 	 *
 	 * @return string|null
 	 */
-	protected function source_block_node( $crawler, $block_attribute_definition ): string|null {
+	protected function source_block_node( $crawler, array $block_attribute_definition ): array|string|null {
 		// 'node' attribute usage was removed from core in 2018, but not officically deprecated until WordPress 6.1:
 		// https://github.com/WordPress/gutenberg/pull/44265
 		// Parsing code for 'node' sources can be found here:
@@ -544,7 +575,7 @@ class ContentParser {
 	 *
 	 * @return array|string|null
 	 */
-	protected function from_dom_node( $node ): array|string|null {
+	protected function from_dom_node( $node ) {
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- external API calls
 
 		if ( XML_TEXT_NODE === $node->nodeType ) {
@@ -575,7 +606,7 @@ class ContentParser {
 	 * 
 	 * @param string $block_name the name of the block
 	 */
-	protected function add_missing_block_warning( $block_name ): void {
+	protected function add_missing_block_warning( string $block_name ): void {
 		$warning_message = sprintf( 'Block type "%s" is not server-side registered. Sourced block attributes will not be available.', $block_name );
 
 		if ( ! in_array( $warning_message, $this->warnings ) ) {

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -40,7 +40,7 @@ class ContentParser {
 	 * 
 	 * @return bool true, if the block should be included or false otherwise
 	 */
-	public function should_block_be_included( array $block, string $block_name, mixed $filter_options ): bool {
+	public function should_block_be_included( array $block, string $block_name, array $filter_options ): bool {
 		$is_block_included = true;
 
 		if ( ! empty( $filter_options['include'] ) ) {
@@ -220,10 +220,10 @@ class ContentParser {
 		/**
 		 * Filters a block when parsing is complete.
 		 *
-		 * @param array[string]array $sourced_block An associative array of parsed block data with keys 'name' and 'attribute'.
+		 * @param array $sourced_block An associative array of parsed block data with keys 'name' and 'attribute'.
 		 * @param string $block_name The name of the parsed block, e.g. 'core/paragraph'.
-		 * @param string $post_id The post ID associated with the parsed block.
-		 * @param string $block The result of parse_blocks() for this block. Contains 'blockName', 'attrs', 'innerHTML', and 'innerBlocks' keys.
+		 * @param int $post_id The post ID associated with the parsed block.
+		 * @param array $block The result of parse_blocks() for this block. Contains 'blockName', 'attrs', 'innerHTML', and 'innerBlocks' keys.
 		 */
 		$sourced_block = apply_filters( 'vip_block_data_api__sourced_block_result', $sourced_block, $block_name, $this->post_id, $block );
 

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -34,9 +34,9 @@ class ContentParser {
 	 * 
 	 * and finally, based on a filter vip_block_data_api__allow_block
 	 * 
-	 * @param array $block
+	 * @param array  $block
 	 * @param string $block_name
-	 * @param array $filter_options
+	 * @param array  $filter_options
 	 * 
 	 * @return bool true, if the block should be included or false otherwise
 	 */
@@ -63,11 +63,11 @@ class ContentParser {
 	/**
 	 * Parses a post's content and returns an array of blocks with their attributes and inner blocks.
 	 * 
-	 * @param string $post_content HTML content of a post.
+	 * @param string   $post_content HTML content of a post.
 	 * @param int|null $post_id ID of the post being parsed. Required for blocks containing meta-sourced attributes and some block filters.
-	 * @param array $filter_options An associative array of options for filtering blocks. Can contain keys:
-	 *              'exclude': An array of block names to block from the response.
-	 *              'include': An array of block names that are allowed in the response.
+	 * @param array    $filter_options An associative array of options for filtering blocks. Can contain keys:
+	 *                 'exclude': An array of block names to block from the response.
+	 *                 'include': An array of block names that are allowed in the response.
 	 *
 	 * @return array|WP_Error
 	 */
@@ -140,7 +140,7 @@ class ContentParser {
 	/**
 	 * Processes a single block, and returns the sourced block data.
 	 * 
-	 * @param array $block
+	 * @param array           $block
 	 * @param WP_Block_Type[] $registered_blocks
 	 *
 	 * @return array|null
@@ -239,7 +239,7 @@ class ContentParser {
 	 * Processes the source attributes of a block.
 	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array $block_attribute_definition
+	 * @param array                                $block_attribute_definition
 	 * 
 	 *  @return array|string|null
 	 */
@@ -284,7 +284,7 @@ class ContentParser {
 	 * Helper function to process the `attribute` source attribute.
 	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array $block_attribute_definition
+	 * @param array                                $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
@@ -311,7 +311,7 @@ class ContentParser {
 	 * Helper function to process the `html` source attribute.
 	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array $block_attribute_definition
+	 * @param array                                $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
@@ -347,7 +347,7 @@ class ContentParser {
 	 * Helper function to process the `text` source attribute.
 	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array $block_attribute_definition
+	 * @param array                                $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
@@ -373,7 +373,7 @@ class ContentParser {
 	 * Helper function to process the `query` source attribute.
 	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array $block_attribute_definition
+	 * @param array                                $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
@@ -409,7 +409,7 @@ class ContentParser {
 	 * Helper function to process the `tag` source attribute.
 	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array $block_attribute_definition
+	 * @param array                                $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
@@ -437,7 +437,7 @@ class ContentParser {
 	 * Helper function to process the `raw` source attribute.
 	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array $block_attribute_definition
+	 * @param array                                $block_attribute_definition
 	 *
 	 * @return string|null
 	 */
@@ -486,7 +486,7 @@ class ContentParser {
 	 * Helper function to process the `children` source attribute.
 	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array $block_attribute_definition
+	 * @param array                                $block_attribute_definition
 	 *
 	 * @return array|string|null
 	 */
@@ -536,7 +536,7 @@ class ContentParser {
 	 * Helper function to process the `node` source attribute.
 	 * 
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler
-	 * @param array $block_attribute_definition
+	 * @param array                                $block_attribute_definition
 	 *
 	 * @return string|null
 	 */

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -70,6 +70,8 @@ class ContentParser {
 	 * @param array  $filter_options Options to be used for filtering, if any.
 	 * 
 	 * @return bool true, if the block should be included or false otherwise
+	 * 
+	 * @access private
 	 */
 	public function should_block_be_included( $block, $block_name, $filter_options ) {
 		$is_block_included = true;
@@ -176,6 +178,8 @@ class ContentParser {
 	 * @param array           $filter_options Options to filter using, if any.
 	 *
 	 * @return array|null
+	 * 
+	 * @access private
 	 */
 	protected function source_block( $block, $registered_blocks, $filter_options ) {
 		$block_name = $block['blockName'];
@@ -274,6 +278,8 @@ class ContentParser {
 	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 * 
 	 *  @return array|string|null
+	 * 
+	 * @access private
 	 */
 	protected function source_attribute( $crawler, $block_attribute_definition ) {
 		$attribute_value         = null;
@@ -319,6 +325,8 @@ class ContentParser {
 	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
+	 * 
+	 * @access private
 	 */
 	protected function source_block_attribute( $crawler, $block_attribute_definition ) {
 		// 'attribute' sources:
@@ -346,6 +354,8 @@ class ContentParser {
 	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
+	 * 
+	 * @access private
 	 */
 	protected function source_block_html( $crawler, $block_attribute_definition ) {
 		// 'html' sources:
@@ -382,6 +392,8 @@ class ContentParser {
 	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
+	 * 
+	 * @access private
 	 */
 	protected function source_block_text( $crawler, $block_attribute_definition ) {
 		// 'text' sources:
@@ -408,6 +420,8 @@ class ContentParser {
 	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
+	 * 
+	 * @access private
 	 */
 	protected function source_block_query( $crawler, $block_attribute_definition ) {
 		// 'query' sources:
@@ -444,6 +458,8 @@ class ContentParser {
 	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
+	 * 
+	 * @access private
 	 */
 	protected function source_block_tag( $crawler, $block_attribute_definition ) {
 		// The only current usage of the 'tag' attribute is Gutenberg core is the 'core/table' block:
@@ -471,6 +487,8 @@ class ContentParser {
 	 * @param Symfony\Component\DomCrawler\Crawler $crawler Crawler instance.
 	 *
 	 * @return string|null
+	 * 
+	 * @access private
 	 */
 	protected function source_block_raw( $crawler ) {
 		// The only current usage of the 'raw' attribute in Gutenberg core is the 'core/html' block:
@@ -493,6 +511,8 @@ class ContentParser {
 	 * @param array $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
+	 * 
+	 * @access private
 	 */
 	protected function source_block_meta( $block_attribute_definition ) {
 		// 'meta' sources:
@@ -520,6 +540,8 @@ class ContentParser {
 	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return array|string|null
+	 * 
+	 * @access private
 	 */
 	protected function source_block_children( $crawler, $block_attribute_definition ) {
 		// 'children' attribute usage was removed from core in 2018, but not officically deprecated until WordPress 6.1:
@@ -570,6 +592,8 @@ class ContentParser {
 	 * @param array                                $block_attribute_definition Definition of the block attribute.
 	 *
 	 * @return string|null
+	 * 
+	 * @access private
 	 */
 	protected function source_block_node( $crawler, $block_attribute_definition ) {
 		// 'node' attribute usage was removed from core in 2018, but not officically deprecated until WordPress 6.1:
@@ -605,6 +629,8 @@ class ContentParser {
 	 * @param \DOMNode $node Node currently being processed.
 	 *
 	 * @return array|string|null
+	 * 
+	 * @access private
 	 */
 	protected function from_dom_node( $node ) {
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- external API calls
@@ -638,6 +664,8 @@ class ContentParser {
 	 * @param string $block_name Name of the block.
 	 * 
 	 * @return void
+	 * 
+	 * @access private
 	 */
 	protected function add_missing_block_warning( $block_name ) {
 		$warning_message = sprintf( 'Block type "%s" is not server-side registered. Sourced block attributes will not be available.', $block_name );
@@ -651,6 +679,8 @@ class ContentParser {
 	 * Check if debug mode is enabled.
 	 * 
 	 * @return bool true if debug is enabled, or false otherwise
+	 * 
+	 * @access private
 	 */
 	protected function is_debug_enabled() {
 		return defined( 'VIP_BLOCK_DATA_API__PARSE_DEBUG' ) && constant( 'VIP_BLOCK_DATA_API__PARSE_DEBUG' ) === true;

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -2,7 +2,6 @@
 /**
  * Content Parser
  * 
- * @file
  * @package vip-block-data-api
  */
 

--- a/src/rest/rest-api.php
+++ b/src/rest/rest-api.php
@@ -2,7 +2,6 @@
 /**
  * Rest API
  * 
- * @file
  * @package vip-block-data-api
  */
 

--- a/src/rest/rest-api.php
+++ b/src/rest/rest-api.php
@@ -27,7 +27,7 @@ class RestApi {
 	}
 
 	/**
-	 * Validate the block names that have been provided, to ensure that they are valid
+	 * Validate block names are non-empty and match a `<prefix>/<block-name>` naming convention.
 	 * 
 	 * @param string $param the block names to validate.
 	 * 

--- a/src/rest/rest-api.php
+++ b/src/rest/rest-api.php
@@ -27,7 +27,7 @@ class RestApi {
 	}
 
 	/**
-	 * Validate block names are non-empty and match a `<prefix>/<block-name>` naming convention.
+	 * Validate block names are non-empty and match a `<namespace>/<block-name>` naming convention.
 	 * 
 	 * @param string $param the block names to validate.
 	 * 
@@ -36,7 +36,6 @@ class RestApi {
 	public static function validate_block_names( $param ) {
 		$block_names = explode( ',', trim( $param ) );
 
-		// Validate that all block names are strings and are in the format of namespace/block-name.
 		foreach ( $block_names as $block_name ) {
 			if ( ! is_string( $block_name ) || ! preg_match( '/^[a-z0-9-]+\/[a-z0-9-]+$/', $block_name ) ) {
 				return false;
@@ -48,6 +47,8 @@ class RestApi {
 
 	/**
 	 * Register the rest routes
+	 * 
+	 * @return void
 	 */
 	public static function register_rest_routes() {
 		register_rest_route( WPCOMVIP__BLOCK_DATA_API__REST_ROUTE, 'posts/(?P<id>[0-9]+)/blocks', [

--- a/src/rest/rest-api.php
+++ b/src/rest/rest-api.php
@@ -115,6 +115,8 @@ class RestApi {
 	 *                 - (optional) include: an array of block names to include
 	 *                 - (optional) exclude: an array of block names to exclude.
 	 * 
+	 * @access private
+	 * 
 	 * @return array|WPError the block contents of the post
 	 */
 	public static function get_block_content( $params ) {

--- a/src/rest/rest-api.php
+++ b/src/rest/rest-api.php
@@ -94,7 +94,7 @@ class RestApi {
 	 * 
 	 * @return array|WPError the block contents of the post
 	 */
-	public static function get_block_content( array $params ): array {
+	public static function get_block_content( $params ) {
 		// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 		$filter_options['exclude'] = $params['exclude'];
 		$filter_options['include'] = $params['include'];

--- a/src/rest/rest-api.php
+++ b/src/rest/rest-api.php
@@ -19,6 +19,8 @@ defined( 'WPCOMVIP__BLOCK_DATA_API__PARSE_TIME_ERROR_MS' ) || define( 'WPCOMVIP_
 class RestApi {
 	/**
 	 * Initialize the Rest API class.
+	 * 
+	 * @access private
 	 */
 	public static function init() {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );

--- a/vip-block-data-api.php
+++ b/vip-block-data-api.php
@@ -23,16 +23,16 @@ if ( ! defined( 'VIP_BLOCK_DATA_API_LOADED' ) ) {
 	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '1.0.1' );
 	define( 'WPCOMVIP__BLOCK_DATA_API__REST_ROUTE', 'vip-block-data-api/v1' );
 
-	// Composer dependencies
+	// Composer dependencies.
 	require_once __DIR__ . '/vendor/autoload.php';
 
-	// /wp-json/ API
+	// /wp-json/ API.
 	require_once __DIR__ . '/src/rest/rest-api.php';
 
-	// Block parsing
+	// Block parsing.
 	require_once __DIR__ . '/src/parser/content-parser.php';
 	require_once __DIR__ . '/src/parser/block-additions/core-image.php';
 
-	// Analytics
+	// Analytics.
 	require_once __DIR__ . '/src/analytics/analytics.php';
 }


### PR DESCRIPTION
## Description

This will add PHPDocs everywhere, and will enable PHPDocs validation as part of the PHPCS checks. This will partially address #41.

Another PR will be incoming in which type hinting will be added. 

## Steps to Test

There should be no tests to run or changes to check because it's only docs that have been updated.

