### PR TITLE
'html' source was converted to 'rich-text' in WordPress 6.5

### DIFF
--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -296,8 +296,8 @@ class ContentParser {
 
 			$attribute_value = $this->source_block_attribute( $crawler, $block_attribute_definition );
 		} elseif ( 'html' === $attribute_source || 'rich-text' === $attribute_source ) {
-            // 'html' source was converted to 'rich-text' in WordPress 6.5.
-            // https://github.com/WordPress/gutenberg/commit/6a42225124e69276a2deec4597a855bb504b37cc
+			// 'html' source was converted to 'rich-text' in WordPress 6.5.
+			// https://github.com/WordPress/gutenberg/commit/6a42225124e69276a2deec4597a855bb504b37cc
 
 			$attribute_value = $this->source_block_html( $crawler, $block_attribute_definition );
 		} elseif ( 'text' === $attribute_source ) {

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -295,7 +295,10 @@ class ContentParser {
 			// https://github.com/WordPress/gutenberg/pull/8276.
 
 			$attribute_value = $this->source_block_attribute( $crawler, $block_attribute_definition );
-		} elseif ( 'html' === $attribute_source ) {
+		} elseif ( 'html' === $attribute_source || 'rich-text' === $attribute_source ) {
+            // 'html' source was converted to 'rich-text' in WordPress 6.5.
+            // https://github.com/WordPress/gutenberg/commit/6a42225124e69276a2deec4597a855bb504b37cc
+
 			$attribute_value = $this->source_block_html( $crawler, $block_attribute_definition );
 		} elseif ( 'text' === $attribute_source ) {
 			$attribute_value = $this->source_block_text( $crawler, $block_attribute_definition );


### PR DESCRIPTION
Starting from WordPress 6.5, `core/table` (and several other) blocks have the `source` attribute as `rich-text` instead of `html`:

- https://github.com/WordPress/gutenberg/commit/6a42225124e69276a2deec4597a855bb504b37cc

Currently, getting the `core/table` block  (and the others) will have the `content` attribute missing.

This PR fixes the problem.