### PR TITLE
Add pre- and post- content filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1218,6 +1218,64 @@ Direct block HTML can be accessed through `$block['innerHTML']`. This may be use
 
 For another example of how this filter can be used to extend block data, we have implemented a default image block filter in [`src/parser/block-additions/core-image.php`][repo-core-image-block-addition]. This filter is automatically called on `core/image` blocks to add `width` and `height` to image attributes.
 
+---
+
+### `vip_block_data_api__before_parse_post_content`
+
+Modify raw post content before it's parsed by the Block Data API.
+
+```php
+/**
+ * Filters content before parsing blocks in a post.
+ *
+ * @param string $post_content The content of the post being parsed.
+ * @param int $post_id Post ID associated with the content.
+ */
+$post_content = apply_filters( 'vip_block_data_api__before_parse_post_content', $post_content, $post_id );
+```
+
+---
+
+### `vip_block_data_api__after_parse_blocks`
+
+Modify the Block Data API REST endpoint response.
+
+```php
+/**
+ * Filters the API result before returning parsed blocks in a post.
+ *
+ * @param string $result The successful API result, contains 'blocks' key with an array
+ *                       of block data, and optionally 'warnings' and 'debug' keys.
+ * @param int $post_id Post ID associated with the content.
+ */
+$result = apply_filters( 'vip_block_data_api__after_parse_blocks', $result, $post_id );
+```
+
+This filter is called directly before returning a result in the REST API. Use this filter to add additional metadata or debug information to the API output.
+
+```php
+add_action( 'vip_block_data_api__after_parse_blocks', 'add_block_data_debug_info', 10, 2 );
+
+function add_block_data_debug_info( $result, $post_id ) {
+	$result['debug']['my-value'] = 123;
+
+	return $result;
+}
+```
+
+This would add `debug.my-value` to all Block Data API REST results:
+
+```bash
+> curl https://my.site/wp-json/vip-block-data-api/v1/posts/1/blocks
+
+{
+  "debug": {
+    "my-value": 123
+  },
+  "blocks": [ /* ... */ ]
+}
+```
+
 ## Analytics
 
 **Please note that, this is for VIP sites only. Analytics are disabled if this plugin is not being run on VIP sites.**

--- a/README.md
+++ b/README.md
@@ -1265,7 +1265,7 @@ assertEquals( [
 
 **Warning**
 
-Be careful with content modification before parsing. In the example above, if a block contained the text "wp:test/invalid-block" outside of a block header, this would also be changed to "core/paragraph". This is likely not the intent of the code.
+Be careful with content modification before parsing. In the example above, if a block contained the text "wp:test/invalid-block" outside of a block header, this would also be changed to "wp:paragraph". This is likely not the intent of the code.
 
 All block markup is sensitive to changes, even changes in whitespace. We've added this filter to make the plugin flexible, but any transforms to `post_content` should be done with extreme care. Strongly consider adding tests to any usage of this filter.
 

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -176,6 +176,15 @@ class ContentParser {
 				'details' => $parsing_error->__toString(),
 			] );
 		} else {
+			/**
+			 * Filters the API result before returning parsed blocks in a post.
+			 *
+			 * @param string $result The successful API result, contains 'blocks'
+			 * key with an array of block data, and optionally 'warnings' and 'debug' keys.
+			 * @param int $post_id Post ID associated with the content.
+			 */
+			$result = apply_filters( 'vip_block_data_api__after_parse_blocks', $result, $post_id );
+
 			return $result;
 		}
 	}

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -128,6 +128,14 @@ class ContentParser {
 		$parsing_error = false;
 
 		try {
+			/**
+			 * Filters content before parsing blocks in a post.
+			 *
+			 * @param string $post_content The content of the post being parsed.
+			 * @param int $post_id Post ID associated with the content.
+			 */
+			$post_content = apply_filters( 'vip_block_data_api__before_parse_post_content', $post_content, $post_id );
+
 			$blocks = parse_blocks( $post_content );
 			$blocks = array_values( array_filter( $blocks, function ( $block ) {
 				$is_whitespace_block = ( null === $block['blockName'] && empty( trim( $block['innerHTML'] ) ) );

--- a/tests/graphql/test-graphql-api.php
+++ b/tests/graphql/test-graphql-api.php
@@ -30,12 +30,12 @@ class GraphQLAPITest extends RegistryTestCase {
             <!-- wp:paragraph -->
             <p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>
             <!-- /wp:paragraph -->
-            
+
             <!-- wp:quote -->
             <blockquote class="wp-block-quote"><!-- wp:paragraph -->
             <p>This is a heading inside a quote</p>
             <!-- /wp:paragraph -->
-            
+
             <!-- wp:quote -->
             <blockquote class="wp-block-quote"><!-- wp:heading -->
             <h2 class="wp-block-heading">This is a heading</h2>
@@ -49,68 +49,60 @@ class GraphQLAPITest extends RegistryTestCase {
 				[
 					'name'       => 'core/paragraph',
 					'attributes' => [
-						array(
+						[
 							'name'  => 'content',
 							'value' => 'Welcome to WordPress. This is your first post. Edit or delete it, then start writing!',
-						),
-						array(
+						],
+						[
 							'name'  => 'dropCap',
 							'value' => '',
-						),
+						],
 					],
 					'id'         => '1',
 				],
 				[
 					'name'        => 'core/quote',
 					'attributes'  => [
-						array(
+						[
 							'name'  => 'value',
 							'value' => '',
-						),
-						array(
-							'name'  => 'citation',
-							'value' => '',
-						),
+						],
 					],
 					'innerBlocks' => [
 						[
 							'name'       => 'core/paragraph',
 							'attributes' => [
-								array(
+								[
 									'name'  => 'content',
 									'value' => 'This is a heading inside a quote',
-								),
-								array(
+								],
+								[
 									'name'  => 'dropCap',
 									'value' => '',
-								),
+								],
 							],
 							'id'         => '3',
 						],
 						[
 							'name'        => 'core/quote',
 							'attributes'  => [
-								array(
+								[
 									'name'  => 'value',
 									'value' => '',
-								),
-								array(
-									'name'  => 'citation',
-									'value' => '',
-								),
+								],
 							],
 							'innerBlocks' => [
 								[
 									'name'       => 'core/heading',
 									'attributes' => [
-										array(
+										[
 											'name'  => 'content',
 											'value' => 'This is a heading',
-										),
-										array(
+										],
+										[
 											'name'  => 'level',
 											'value' => '2',
-										),
+										],
 									],
 									'id'         => '5',
 								],
@@ -137,68 +129,60 @@ class GraphQLAPITest extends RegistryTestCase {
 			[
 				'name'       => 'core/paragraph',
 				'attributes' => [
-					array(
+					[
 						'name'  => 'content',
 						'value' => 'Welcome to WordPress. This is your first post. Edit or delete it, then start writing!',
-					),
-					array(
+					],
+					[
 						'name'  => 'dropCap',
 						'value' => '',
-					),
+					],
 				],
 				'id'         => '2',
 			],
 			[
 				'name'        => 'core/quote',
 				'attributes'  => [
-					array(
+					[
 						'name'  => 'value',
 						'value' => '',
-					),
-					array(
-						'name'  => 'citation',
-						'value' => '',
-					),
+					],
 				],
 				'innerBlocks' => [
 					[
 						'name'       => 'core/paragraph',
 						'attributes' => [
-							array(
+							[
 								'name'  => 'content',
 								'value' => 'This is a heading inside a quote',
-							),
-							array(
+							],
+							[
 								'name'  => 'dropCap',
 								'value' => '',
-							),
+							],
 						],
 						'id'         => '4',
 					],
 					[
 						'name'        => 'core/quote',
 						'attributes'  => [
-							array(
+							[
 								'name'  => 'value',
 								'value' => '',
-							),
-							array(
-								'name'  => 'citation',
-								'value' => '',
-							),
+							],
 						],
 						'innerBlocks' => [
 							[
 								'name'       => 'core/heading',
 								'attributes' => [
-									array(
+									[
 										'name'  => 'content',
 										'value' => 'This is a heading',
-									),
-									array(
+									],
+									[
 										'name'  => 'level',
 										'value' => '2',
-									),
+									],
 								],
 								'id'         => '6',
 							],
@@ -214,14 +198,14 @@ class GraphQLAPITest extends RegistryTestCase {
 			[
 				'name'       => 'core/paragraph',
 				'attributes' => [
-					array(
+					[
 						'name'  => 'content',
 						'value' => 'Welcome to WordPress. This is your first post. Edit or delete it, then start writing!',
-					),
-					array(
+					],
+					[
 						'name'  => 'dropCap',
 						'value' => '',
-					),
+					],
 				],
 				'parentId'   => '1',
 				'id'         => '2',
@@ -229,14 +213,10 @@ class GraphQLAPITest extends RegistryTestCase {
 			[
 				'name'       => 'core/quote',
 				'attributes' => [
-					array(
+					[
 						'name'  => 'value',
 						'value' => '',
-					),
-					array(
-						'name'  => 'citation',
-						'value' => '',
-					),
+					],
 				],
 				'id'         => '3',
 				'parentId'   => '1',
@@ -244,14 +224,14 @@ class GraphQLAPITest extends RegistryTestCase {
 			[
 				'name'       => 'core/paragraph',
 				'attributes' => [
-					array(
+					[
 						'name'  => 'content',
 						'value' => 'This is a heading inside a quote',
-					),
-					array(
+					],
+					[
 						'name'  => 'dropCap',
 						'value' => '',
-					),
+					],
 				],
 				'id'         => '4',
 				'parentId'   => '3',
@@ -259,14 +239,10 @@ class GraphQLAPITest extends RegistryTestCase {
 			[
 				'name'       => 'core/quote',
 				'attributes' => [
-					array(
+					[
 						'name'  => 'value',
 						'value' => '',
-					),
-					array(
-						'name'  => 'citation',
-						'value' => '',
-					),
+					],
 				],
 				'id'         => '5',
 				'parentId'   => '3',
@@ -274,14 +250,14 @@ class GraphQLAPITest extends RegistryTestCase {
 			[
 				'name'       => 'core/heading',
 				'attributes' => [
-					array(
+					[
 						'name'  => 'content',
 						'value' => 'This is a heading',
-					),
-					array(
+					],
+					[
 						'name'  => 'level',
 						'value' => '2',
-					),
+					],
 				],
 				'id'         => '6',
 				'parentId'   => '5',

--- a/tests/parser/test-content-parser.php
+++ b/tests/parser/test-content-parser.php
@@ -13,62 +13,6 @@ namespace WPCOMVIP\BlockDataApi;
 class ContentParserTest extends RegistryTestCase {
 	/* Multiple attributes */
 
-	public function test_block_filter_via_code() {
-		$this->register_block_with_attributes( 'test/block1', [
-			'content' => [
-				'type'     => 'string',
-				'source'   => 'html',
-				'selector' => 'div.a',
-			],
-		] );
-
-		$this->register_block_with_attributes( 'test/block2', [
-			'url' => [
-				'type'      => 'string',
-				'source'    => 'attribute',
-				'selector'  => 'img',
-				'attribute' => 'src',
-			],
-		] );
-
-		$html = '
-			<!-- wp:test/block1 -->
-			<div class="a">Block 1</div>
-			<!-- /wp:test/block1 -->
-
-			<!-- wp:test/block2 -->
-			<img src="/image.jpg" />
-			<!-- /wp:test/block2 -->
-		';
-
-		$expected_blocks = [
-			[
-				'name'       => 'test/block1',
-				'attributes' => [
-					'content' => 'Block 1',
-				],
-			],
-		];
-
-		$block_filter_function = function ( $is_block_included, $block_name ) {
-			if ( 'test/block2' === $block_name ) {
-				return false;
-			} else {
-				return true;
-			}
-		};
-
-		add_filter( 'vip_block_data_api__allow_block', $block_filter_function, 10, 2 );
-		$content_parser = new ContentParser( $this->registry );
-		$blocks         = $content_parser->parse( $html );
-		remove_filter( 'vip_block_data_api__allow_block', $block_filter_function, 10, 2 );
-
-		$this->assertArrayNotHasKey( 'errors', $blocks );
-		$this->assertNotEmpty( $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
-		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
-		$this->assertEquals( $expected_blocks, $blocks['blocks'] );
-	}
-
 	public function test_parse_multiple_attributes_from_block() {
 		$this->register_block_with_attributes( 'test/captioned-image', [
 			'caption' => [

--- a/tests/parser/test-parser-filters.php
+++ b/tests/parser/test-parser-filters.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Class ContentParserTest
+ *
+ * @package vip-block-data-api
+ */
+
+namespace WPCOMVIP\BlockDataApi;
+
+/**
+ * Content parser filter testing.
+ */
+class ParserFiltersTest extends RegistryTestCase {
+	/* vip_block_data_api__allow_block filter */
+
+	public function test_allow_block_filter_via_code() {
+		$this->register_block_with_attributes( 'test/block1', [
+			'content' => [
+				'type'     => 'string',
+				'source'   => 'html',
+				'selector' => 'div.a',
+			],
+		] );
+
+		$this->register_block_with_attributes( 'test/block2', [
+			'url' => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'img',
+				'attribute' => 'src',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/block1 -->
+			<div class="a">Block 1</div>
+			<!-- /wp:test/block1 -->
+
+			<!-- wp:test/block2 -->
+			<img src="/image.jpg" />
+			<!-- /wp:test/block2 -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'test/block1',
+				'attributes' => [
+					'content' => 'Block 1',
+				],
+			],
+		];
+
+		$block_filter_function = function ( $is_block_included, $block_name ) {
+			if ( 'test/block2' === $block_name ) {
+				return false;
+			} else {
+				return true;
+			}
+		};
+
+		add_filter( 'vip_block_data_api__allow_block', $block_filter_function, 10, 2 );
+		$content_parser = new ContentParser( $this->registry );
+		$blocks         = $content_parser->parse( $html );
+		remove_filter( 'vip_block_data_api__allow_block', $block_filter_function, 10, 2 );
+
+		$this->assertArrayNotHasKey( 'errors', $blocks );
+		$this->assertNotEmpty( $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertEquals( $expected_blocks, $blocks['blocks'] );
+	}
+
+	public function test_before_parse_post_content_filter() {
+		$this->register_block_with_attributes( 'test/valid-block', [
+			'content' => [
+				'type'     => 'rich-text',
+				'source'   => 'rich-text',
+				'selector' => 'code',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/invalid-block -->
+			<code><strong>Block content</strong>!</code>
+			<!-- /wp:test/invalid-block -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'test/valid-block',
+				'attributes' => [
+					'content' => '<strong>Block content</strong>!',
+				],
+			],
+		];
+
+		$replace_post_content_filter = function ( $post_content ) {
+			return str_replace( 'test/invalid-block', 'test/valid-block', $post_content );
+		};
+
+		add_filter( 'vip_block_data_api__before_parse_post_content', $replace_post_content_filter );
+		$content_parser = new ContentParser( $this->registry );
+		$blocks         = $content_parser->parse( $html );
+		remove_filter( 'vip_block_data_api__before_parse_post_content', $replace_post_content_filter );
+
+		$this->assertArrayNotHasKey( 'errors', $blocks );
+		$this->assertNotEmpty( $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertEquals( $expected_blocks, $blocks['blocks'] );
+	}
+}

--- a/tests/rest/test-rest-api.php
+++ b/tests/rest/test-rest-api.php
@@ -209,7 +209,7 @@ class RestApiTest extends WP_UnitTestCase {
 
 		$request = new WP_REST_Request( 'GET', sprintf( '/vip-block-data-api/v1/posts/%d/blocks', $post_id ) );
 		// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
-		$request->set_query_params( array( 'exclude' => 'core/paragraph,core/separator' ) );
+		$request->set_query_params( [ 'exclude' => 'core/paragraph,core/separator' ] );
 
 		$response = $this->server->dispatch( $request );
 
@@ -270,7 +270,7 @@ class RestApiTest extends WP_UnitTestCase {
 		];
 
 		$request = new WP_REST_Request( 'GET', sprintf( '/vip-block-data-api/v1/posts/%d/blocks', $post_id ) );
-		$request->set_query_params( array( 'include' => 'core/heading' ) );
+		$request->set_query_params( [ 'include' => 'core/heading' ] );
 
 		$response = $this->server->dispatch( $request );
 
@@ -430,11 +430,11 @@ class RestApiTest extends WP_UnitTestCase {
 		$this->expectExceptionMessage( 'vip-block-data-api-invalid-params' );
 
 		$request = new WP_REST_Request( 'GET', sprintf( '/vip-block-data-api/v1/posts/%d/blocks', $post_id ) );
-		$request->set_query_params( array(
+		$request->set_query_params( [
 			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 			'exclude' => 'core/paragraph,core/separator',
 			'include' => 'core/heading,core/quote,core/media-text',
-		) );
+		] );
 
 		$response = $this->server->dispatch( $request );
 


### PR DESCRIPTION
## Description

Add a new filter for modifying post content before it is parsed, and another for after content is parsed:

### `vip_block_data_api__before_parse_post_content`

Modify raw post content before it's parsed by the Block Data API.

```php
/**
 * Filters content before parsing blocks in a post.
 *
 * @param string $post_content The content of the post being parsed.
 * @param int $post_id Post ID associated with the content.
 */
$post_content = apply_filters( 'vip_block_data_api__before_parse_post_content', $post_content, $post_id );
```

---

### `vip_block_data_api__after_parse_blocks`

Modify the Block Data API REST endpoint response.

```php
/**
 * Filters the API result before returning parsed blocks in a post.
 *
 * @param string $result The successful API result, contains 'blocks' key with an array
 *                       of block data, and optionally 'warnings' and 'debug' keys.
 * @param int $post_id Post ID associated with the content.
 */
$result = apply_filters( 'vip_block_data_api__after_parse_blocks', $result, $post_id );
```

## Steps to Test

Tests have been added both of the new filters in `tests/parser/test-parser-filters.php`. To test:

```bash
$ wp-env start
$ composer install
$ composer run test

> wp-env run tests-cli --env-cwd=wp-content/plugins/vip-block-data-api ./vendor/bin/phpunit
ℹ Starting './vendor/bin/phpunit' on the tests-cli container. 

....................................................              52 / 52 (100%)

Time: 00:00.270, Memory: 56.50 MB

OK (52 tests, 122 assertions)
✔ Ran `./vendor/bin/phpunit` in 'tests-cli'. (in 3s 227ms)
```
