### PR TITLE
Fix "Array" values in GraphQL block array data

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,85 @@ The attributes of a block in GraphQL are available in a list of `name` / `value`
 
 This is used instead of a key-value structure. This is a trade-off that makes it easy to retrieve block attributes without specifying the the block type ahead of time, but attribute type information is lost.
 
+
+#### Complex attributes
+
+Some block attributes contain arrays or complex nested values. Demonstrated below, [the `core/table` block uses an array of objects][gutenberg-code-table-body] to represent head, body, and footer cell contents. The GraphQL Block Data API implementation represents these attributes as JSON-encoded strings along with the `isValueJsonEncoded` boolean field. When `isValueJsonEncoded` is `true`, an attribute's value must be JSON decoded to get the original complex value.
+
+For example, using this table:
+
+![Example core/table block with a two header cells and two body cells][media-example-table]
+
+We can query for attributes along with the `isValueJsonEncoded` field in a GraphQL query:
+
+```graphql
+query PostQuery {
+  post(id: 1, idType: DATABASE_ID) {
+    blocksData {
+      blocks {
+        attributes {
+          name
+          value
+          isValueJsonEncoded
+        }
+        id
+        name
+        innerBlocks {
+          attributes {
+            name
+            value
+            isValueJsonEncoded
+          }
+          id
+          name
+          parentId
+        }
+      }
+    }
+  }
+}
+```
+
+The result will contain JSON-encoded attributes designated by the `isValueJsonEncoded` field:
+
+```json
+{
+  "data": {
+    "post": {
+      "blocksData": {
+        "blocks": [
+          {
+            "name": "core/table",
+            "attributes": [
+              {
+                "name": "hasFixedLayout",
+                "value": "",
+                "isValueJsonEncoded": false
+              },
+              {
+                "name": "head",
+                "value": "[{\"cells\":[{\"content\":\"Header A\",\"tag\":\"th\"},{\"content\":\"Header B\",\"tag\":\"th\"}]}]",
+                "isValueJsonEncoded": true
+              },
+              {
+                "name": "body",
+                "value": "[{\"cells\":[{\"content\":\"Value 1\",\"tag\":\"td\"},{\"content\":\"Value 2\",\"tag\":\"td\"}]}]",
+                "isValueJsonEncoded": true
+              },
+              {
+                "name": "foot",
+                "value": "[]",
+                "isValueJsonEncoded": true
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
 ---
 
 #### Example: Simple nested blocks: `core/list` and `core/quote`
@@ -1405,6 +1484,7 @@ composer run test
 
 <!-- Links -->
 [gutenberg-code-image-caption]: https://github.com/WordPress/gutenberg/blob/3d2a6d7eaa4509c4d89bde674e9b73743868db2c/packages/block-library/src/image/block.json#L30-L35
+[gutenberg-code-table-body]: https://github.com/WordPress/gutenberg/blob/74a06c73613d9f90d66905c14d36eda19101999e/packages/block-library/src/table/block.json#L64-L108
 [gutenberg-pr-core-list-innerblocks]: https://href.li/?https://github.com/WordPress/gutenberg/pull/39487
 [media-example-caption-plain]: https://github.com/Automattic/vip-block-data-api/blob/media/example-caption-plain.png
 [media-example-caption-rich-text]: https://github.com/Automattic/vip-block-data-api/blob/media/example-caption-rich-text.png
@@ -1412,6 +1492,7 @@ composer run test
 [media-example-list-quote]: https://github.com/Automattic/vip-block-data-api/blob/media/example-utility-quote-list.png
 [media-example-media-text]: https://github.com/Automattic/vip-block-data-api/blob/media/example-media-text.png
 [media-example-pullquote]: https://github.com/Automattic/vip-block-data-api/blob/media/example-pullquote.png
+[media-example-table]: https://github.com/Automattic/vip-block-data-api/blob/media/example-table.png
 [media-example-utility-quote-list]: https://github.com/Automattic/vip-block-data-api/blob/media/example-list-quote.png
 [media-plugin-activate]: https://github.com/Automattic/vip-block-data-api/blob/media/plugin-activate.png
 [media-preact-media-text]: https://github.com/Automattic/vip-block-data-api/blob/media/preact-media-text.png

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This plugin is currently developed for use on WordPress sites hosted on the VIP 
     - [Setup](#setup)
     - [Usage](#usage-1)
     - [Block Attributes](#block-attributes)
+    - [Complex attributes](#complex-attributes)
     - [Example: Simple nested blocks: `core/list` and `core/quote`](#example-simple-nested-blocks-corelist-and-corequote)
 - [API Consumption](#api-consumption)
   - [Preact](#preact)

--- a/src/graphql/graphql-api.php
+++ b/src/graphql/graphql-api.php
@@ -91,12 +91,7 @@ class GraphQLApi {
 			unset( $block['attributes'] );
 		} elseif ( isset( $block['attributes'] ) && ! empty( $block['attributes'] ) ) {
 			$block['attributes'] = array_map(
-				function ( $name, $value ) {
-					return [
-						'name'  => $name,
-						'value' => strval( $value ),
-					];
-				},
+				[ __CLASS__, 'get_block_attribute_pair' ],
 				array_keys( $block['attributes'] ),
 				array_values( $block['attributes'] )
 			);
@@ -251,6 +246,23 @@ class GraphQLApi {
 				'resolve'     => [ __CLASS__, 'get_blocks_data' ],
 			]
 		);
+	}
+
+	/**
+	 * Given a block attribute name and value, return a BlockAttribute array.
+	 *
+	 * @return array
+	 */
+	public static function get_block_attribute_pair( $name, $value ) {
+		// Unknown array types (table cells, for example) are encoded as JSON strings.
+		if ( is_array( $value ) ) {
+			$value = wp_json_encode( $value );
+		}
+
+		return [
+			'name'  => $name,
+			'value' => strval( $value ),
+		];
 	}
 }
 

--- a/src/graphql/graphql-api.php
+++ b/src/graphql/graphql-api.php
@@ -25,7 +25,7 @@ class GraphQLApi {
 	}
 
 	/**
-	 * Extract the blocks data for a post, and return back in the format expected by the graphQL API.
+	 * Extract the blocks data for a post, and return back in the format expected by the GraphQL API.
 	 *
 	 * @param  \WPGraphQL\Model\Post $post_model Post model for post.
 	 *
@@ -154,13 +154,17 @@ class GraphQLApi {
 			[
 				'description' => 'Block attribute',
 				'fields'      => [
-					'name'  => [
+					'name'               => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => 'Block data attribute name',
 					],
-					'value' => [
+					'value'              => [
 						'type'        => [ 'non_null' => 'String' ],
 						'description' => 'Block data attribute value',
+					],
+					'isValueJsonEncoded' => [
+						'type'        => [ 'non_null' => 'Boolean' ],
+						'description' => 'True if value is a complex JSON-encoded field. This is used to encode attribute types like arrays and objects.',
 					],
 				],
 			],
@@ -258,13 +262,17 @@ class GraphQLApi {
 	 */
 	public static function get_block_attribute_pair( $name, $value ) {
 		// Unknown array types (table cells, for example) are encoded as JSON strings.
-		if ( is_array( $value ) ) {
-			$value = wp_json_encode( $value );
+		$is_value_json_encoded = false;
+
+		if ( ! is_scalar( $value ) ) {
+			$value                 = wp_json_encode( $value );
+			$is_value_json_encoded = true;
 		}
 
 		return [
-			'name'  => $name,
-			'value' => strval( $value ),
+			'name'               => $name,
+			'value'              => strval( $value ),
+			'isValueJsonEncoded' => $is_value_json_encoded,
 		];
 	}
 }

--- a/src/graphql/graphql-api.php
+++ b/src/graphql/graphql-api.php
@@ -251,6 +251,9 @@ class GraphQLApi {
 	/**
 	 * Given a block attribute name and value, return a BlockAttribute array.
 	 *
+	 * @param string $name The name of the block attribute.
+	 * @param mixed  $value The value of the block attribute.
+	 *
 	 * @return array
 	 */
 	public static function get_block_attribute_pair( $name, $value ) {

--- a/tests/graphql/test-graphql-api.php
+++ b/tests/graphql/test-graphql-api.php
@@ -27,22 +27,22 @@ class GraphQLAPITest extends RegistryTestCase {
 
 	public function test_get_blocks_data() {
 		$html = '
-            <!-- wp:paragraph -->
-            <p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>
-            <!-- /wp:paragraph -->
+			<!-- wp:paragraph -->
+			<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>
+			<!-- /wp:paragraph -->
 
-            <!-- wp:quote -->
-            <blockquote class="wp-block-quote"><!-- wp:paragraph -->
-            <p>This is a heading inside a quote</p>
-            <!-- /wp:paragraph -->
+			<!-- wp:quote -->
+			<blockquote class="wp-block-quote"><!-- wp:paragraph -->
+			<p>This is a heading inside a quote</p>
+			<!-- /wp:paragraph -->
 
-            <!-- wp:quote -->
-            <blockquote class="wp-block-quote"><!-- wp:heading -->
-            <h2 class="wp-block-heading">This is a heading</h2>
-            <!-- /wp:heading --></blockquote>
-            <!-- /wp:quote --></blockquote>
-            <!-- /wp:quote -->
-        ';
+			<!-- wp:quote -->
+			<blockquote class="wp-block-quote"><!-- wp:heading -->
+			<h2 class="wp-block-heading">This is a heading</h2>
+			<!-- /wp:heading --></blockquote>
+			<!-- /wp:quote --></blockquote>
+			<!-- /wp:quote -->
+		';
 
 		$expected_blocks = [
 			'blocks' => [
@@ -267,5 +267,73 @@ class GraphQLAPITest extends RegistryTestCase {
 		$flattened_blocks = GraphQLApi::flatten_inner_blocks( $inner_blocks, '1' );
 
 		$this->assertEquals( $expected_blocks, $flattened_blocks );
+	}
+
+	public function test_array_data_in_attribute() {
+		$html = '
+			<!-- wp:table -->
+			<figure class="wp-block-table">
+				<table>
+					<thead>
+						<tr>
+							<th>Header A</th>
+							<th>Header B</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>Value A</td>
+							<td>Value B</td>
+						</tr>
+						<tr>
+							<td>Value C</td>
+							<td>Value D</td>
+						</tr>
+					</tbody>
+					<tfoot>
+						<tr>
+							<td>Footer A</td>
+							<td>Footer B</td>
+						</tr>
+					</tfoot>
+				</table>
+			</figure>
+			<!-- /wp:table -->
+		';
+
+		$expected_blocks = [
+			'blocks' => [
+				[
+					'name'       => 'core/table',
+					'attributes' => [
+						[
+							'name'  => 'hasFixedLayout',
+							'value' => false,
+						],
+						[
+							'name'  => 'head',
+							'value' => '[{"cells":[{"content":"Header A","tag":"th"},{"content":"Header B","tag":"th"}]}]',
+						],
+						[
+							'name'  => 'body',
+							'value' => '[{"cells":[{"content":"Value A","tag":"td"},{"content":"Value B","tag":"td"}]},{"cells":[{"content":"Value C","tag":"td"},{"content":"Value D","tag":"td"}]}]',
+						],
+						[
+							'name'  => 'foot',
+							'value' => '[{"cells":[{"content":"Footer A","tag":"td"},{"content":"Footer B","tag":"td"}]}]',
+						],
+					],
+					'id'         => '6',
+				],
+			],
+		];
+
+		$post = $this->factory()->post->create_and_get( [
+			'post_content' => $html,
+		] );
+
+		$blocks_data = GraphQLApi::get_blocks_data( $post );
+
+		$this->assertEquals( $expected_blocks, $blocks_data );
 	}
 }

--- a/vip-block-data-api.php
+++ b/vip-block-data-api.php
@@ -5,7 +5,7 @@
  * Description: Access Gutenberg block data in JSON via the REST API.
  * Author: WordPress VIP
  * Text Domain: vip-block-data-api
- * Version: 1.2.2
+ * Version: 1.2.3
  * Requires at least: 5.9.0
  * Tested up to: 6.4
  * Requires PHP: 8.0
@@ -20,7 +20,7 @@ namespace WPCOMVIP\BlockDataApi;
 if ( ! defined( 'VIP_BLOCK_DATA_API_LOADED' ) ) {
 	define( 'VIP_BLOCK_DATA_API_LOADED', true );
 
-	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '1.2.2' );
+	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '1.2.3' );
 	define( 'WPCOMVIP__BLOCK_DATA_API__REST_ROUTE', 'vip-block-data-api/v1' );
 
 	// Analytics related configs.


### PR DESCRIPTION
## Description

See #53 for a description of the problem. In short, the code that maps block attributes into GraphQL types coerces the `value` property into a string:

https://github.com/Automattic/vip-block-data-api/blob/f89ed3c742e8d56dd4cda55056dc738422ffa33e/src/graphql/graphql-api.php#L93-L102

This causes an `'Array'` string to replace the actual value, which makes `array` data inaccessible through WPGraphQL. Additionally, this coercion produces a notice:

```
PHP Warning:  Array to string conversion in /.../vip-block-data-api/src/graphql/graphql-api.php on line 97
```

## Why JSON?

The fix in this PR checks for arrays in the `value` property, and converts those to a JSON string representation. This was selected instead of per-block custom properties or union types.

`array`-source values can represent arbitrarily complex data which could require adding a new type for each block. For example, the `head`, `body`, and `foot` of a table follow a structured `cell`-based pattern:

```json
{
    "name": "core/table",
    "attributes": {
        "hasFixedLayout": false,
        "head": [
            { "cells": [
                { "content": "Header A", "tag": "th" },
                { "content": "Header B", "tag": "th" }
            ] }
        ],
        "body": [
            { "cells": [
                { "content": "Value A", "tag": "td" },
                { "content": "Value B", "tag": "td" }
            ] },
            { "cells": [
                { "content": "Value C", "tag": "td" },
                { "content": "Value D", "tag": "td" }
            ] }
        ],
        "foot": [
            { "cells": [
                { "content": "Footer A", "tag": "td"},
                { "content": "Footer B", "tag": "td" }
            ] }
        ]
    }
}
```

That's because `core/table` uses a [`query` with a known structure](https://github.com/WordPress/gutenberg/blob/74a06c7/packages/block-library/src/table/block.json#L24) to fill those values.

However, other uses of `array` values, like the [`tracks` attribute of `core/video`](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/video/block.json#L72-L79) use a freeform structure:

```json
{
    "name": "core/video",
    "attributes": {
        "src": "http://my.site/wp-content/uploads/my-video.mp4",
        "tracks": [
            {
                "src": "http://my.site/wp-content/uploads/track-en.vtt",
                "label": "track-en",
                "srcLang": "en"
            },
            {
                "src": "http://my.site/wp-content/uploads/track-fr.vtt",
                "label": "track-fr",
                "srcLang": "fr",
                "kind": "subtitles"
            }
        ]
    }
}
```

If we tried to cover known core `array` types with custom types, this still wouldn't solve the problem for custom blocks. JSON representation will allow the GraphQL backend to model arbitrarily complex nested types without needing to know their structure beforehand.

The primary downside is that consumers of the data will be required to know that the block contains JSON-encoded information for `array`-type values.

However, that doesn't change the existing model for querying. All attribute values are already treated as `String` type [as a trade-off for convenience](https://github.com/Automattic/vip-block-data-api/blob/b0fc4b7/README.md?plain=1#L377). Also, given that array values were completely clobbered into an `"Array"` string previously, this is an improvement.

## Steps to Test

A test using `core/table` was added in [`test_array_data_in_attribute()`](https://github.com/Automattic/vip-block-data-api/blob/7bfc3c684112c413ee2cbaa2192722bcb0aa9675/tests/graphql/test-graphql-api.php#L272). To run tests:

1. Check out PR.
1. Run `wp-env start`
1. Run `composer install`
1. Run `composer run test`

Fixes #53 