### PR TITLE
Update RELEASE.md with tag signing, mu-plugins updates

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,14 +20,14 @@
 
 ## 3. Tag branch for release
 
-1. In `trunk`, add a tag for the release:
+1. In `trunk`, add a signed tag for the release:
 
     ```bash
     git checkout trunk
     git pull
-    git tag -a <version> -m "Release <version>"
+    git tag -s -a <version> -m "Release <version>"
 
-    # e.g. git tag -a 1.0.2 -m "Release 1.0.2"
+    # e.g. git tag -s -a 1.0.2 -m "Release 1.0.2"
     ```
 
 2. Run `git push --tags`.
@@ -50,3 +50,17 @@
 5. Add a description of release changes.
 6. Attach the plugin ZIP.
 7. Click "Publish release."
+
+## 5. Update integrations
+
+Patch updates (e.g. `1.2.3` -> `1.2.4`) do not require any additional steps.
+
+This section applies if the plugin has increased by a minor (e.g. `1.2` -> `1.3`) or major (e.g. `1.2` -> `2.0`) version. 
+
+For an example PR updating the integration version, [see this PR](https://github.com/Automattic/vip-go-mu-plugins/pull/5409/files).
+
+1. Ensure that the latest release of the Block Data API plugin has been [pulled in `vip-go-mu-plugins-ext`](https://github.com/Automattic/vip-go-mu-plugins-ext/tree/trunk/vip-integrations). Updates are synced by minor version, so a patch update of `1.2.3` will be pulled into `vip-integrations/vip-block-data-api-1.2`. If it's not, wait for the [**Update versioned external dependencies** workflow](https://github.com/Automattic/vip-go-mu-plugins-ext/actions/workflows/update-deps.yml) to pull in the latest changes, or run it manually.
+
+2. Create a branch on [vip-go-mu-plugins](https://github.com/Automattic/vip-go-mu-plugins).
+3. Update the `integrations/block-data-api.php` version to match the minor version of the plugin, e.g. `1.2`. This will correspond with the folder path for the plugin [in `vip-go-mu-plugins-ext`](https://github.com/Automattic/vip-go-mu-plugins-ext/tree/trunk/vip-integrations).
+4. Submit the PR, get it approved, and merge.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -57,7 +57,7 @@ Patch updates (e.g. `1.2.3` -> `1.2.4`) do not require any additional steps.
 
 This section applies if the plugin has increased by a minor (e.g. `1.2` -> `1.3`) or major (e.g. `1.2` -> `2.0`) version. 
 
-For an example PR updating the integration version, [see this PR](https://github.com/Automattic/vip-go-mu-plugins/pull/5409/files).
+For an example updating an integration version, [see this mu-plugins PR](https://github.com/Automattic/vip-go-mu-plugins/pull/5409).
 
 1. Ensure that the latest release of the Block Data API plugin has been [pulled in `vip-go-mu-plugins-ext`](https://github.com/Automattic/vip-go-mu-plugins-ext/tree/trunk/vip-integrations). Updates are synced by minor version, so a patch update of `1.2.3` will be pulled into `vip-integrations/vip-block-data-api-1.2`. If it's not, wait for the [**Update versioned external dependencies** workflow](https://github.com/Automattic/vip-go-mu-plugins-ext/actions/workflows/update-deps.yml) to pull in the latest changes, or run it manually.
 


### PR DESCRIPTION
## Description

Adds two changes to `RELEASE.md`:

1. Ensure git tags are signed with `-s`.
2. Add a section on updating mu-plugins' integration version on minor or major version changes.