### PR TITLE
[HOTFIX] Content parser selectors

### DIFF
--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -361,7 +361,7 @@ class ContentParser {
 		$selector        = $block_attribute_definition['selector'] ?? null;
 
 		if ( null !== $selector ) {
-			$crawler = $crawler->filter( $selector );
+			$crawler = $crawler->children()->filter( $selector );
 		}
 
 		if ( $crawler->count() > 0 ) {


### PR DESCRIPTION
## Description

For some specific use cases, such as retrieving the anchor attributes from the HTML of every block, the API may unexpectedly return `null`.

For example:
- If the universal CSS selector is used (`*`) then the first node returned by `$crawler->filter( $selector );` will be the `body` element that doesn't contain any attribute, so the `$crawler->attr( $attribute );` will always return `null`.

To avoid this outcome, we can modify the `source_block_attribute` method in order to filter the elements within the `body` element.

## Steps to Test

1. Check out PR.
2. Run `composer run test`.

