### PR TITLE
Extend complex types

### DIFF
--- a/src/graphql/graphql-api.php
+++ b/src/graphql/graphql-api.php
@@ -261,10 +261,10 @@ class GraphQLApi {
 	 * @return array
 	 */
 	public static function get_block_attribute_pair( $name, $value ) {
-		// Unknown array types (table cells, for example) are encoded as JSON strings.
+		// Non-string types (numbers, booleans, arrays, objects, for example) are encoded as JSON strings.
 		$is_value_json_encoded = false;
 
-		if ( ! is_scalar( $value ) ) {
+		if ( ! is_string( $value ) ) {
 			$value                 = wp_json_encode( $value );
 			$is_value_json_encoded = true;
 		}

--- a/tests/graphql/test-graphql-api.php
+++ b/tests/graphql/test-graphql-api.php
@@ -7,10 +7,19 @@
 
 namespace WPCOMVIP\BlockDataApi;
 
+use GraphQLRelay\Relay;
+
 /**
  * Tests for the GraphQL API.
  */
 class GraphQLAPITest extends RegistryTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Reset block ID counter before each test
+		Relay::reset();
+	}
 
 	public function test_is_graphql_enabled_true() {
 		$this->assertTrue( apply_filters( 'vip_block_data_api__is_graphql_enabled', true ) );

--- a/tests/graphql/test-graphql-api.php
+++ b/tests/graphql/test-graphql-api.php
@@ -104,8 +104,8 @@ class GraphQLAPITest extends RegistryTestCase {
 						],
 						[
 							'name'               => 'dropCap',
-							'value'              => '',
-							'isValueJsonEncoded' => false,
+							'value'              => 'false',
+							'isValueJsonEncoded' => true,
 						],
 					],
 					'id'         => '1',
@@ -130,8 +130,8 @@ class GraphQLAPITest extends RegistryTestCase {
 								],
 								[
 									'name'               => 'dropCap',
-									'value'              => '',
-									'isValueJsonEncoded' => false,
+									'value'              => 'false',
+									'isValueJsonEncoded' => true,
 								],
 							],
 							'id'         => '3',
@@ -157,7 +157,7 @@ class GraphQLAPITest extends RegistryTestCase {
 										[
 											'name'  => 'level',
 											'value' => '2',
-											'isValueJsonEncoded' => false,
+											'isValueJsonEncoded' => true,
 										],
 									],
 									'id'         => '5',

--- a/tests/graphql/test-graphql-api.php
+++ b/tests/graphql/test-graphql-api.php
@@ -189,6 +189,8 @@ class GraphQLAPITest extends RegistryTestCase {
 		$this->assertEquals( $expected_blocks, $blocks_data );
 	}
 
+	// get_blocks_data() attribute type tests
+
 	public function test_array_data_in_attribute() {
 		$this->register_global_block_with_attributes( 'test/custom-table', [
 			'head' => [
@@ -320,7 +322,145 @@ class GraphQLAPITest extends RegistryTestCase {
 							'isValueJsonEncoded' => true,
 						],
 					],
-					'id'         => '6',
+					'id'         => '1',
+				],
+			],
+		];
+
+		$post = $this->factory()->post->create_and_get( [
+			'post_content' => $html,
+		] );
+
+		$blocks_data = GraphQLApi::get_blocks_data( $post );
+
+		$this->assertEquals( $expected_blocks, $blocks_data );
+	}
+
+	public function test_get_block_data_with_boolean_attributes() {
+		$this->register_global_block_with_attributes( 'test/toggle-text', [
+			'isVisible'  => [
+				'type' => 'boolean',
+			],
+			'isBordered' => [
+				'type' => 'boolean',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/toggle-text { "isVisible": true, "isBordered": false } -->
+			<div>Block</div>
+			<!-- /wp:test/toggle-text -->
+		';
+
+		$expected_blocks = [
+			'blocks' => [
+				[
+					'id'         => '1',
+					'name'       => 'test/toggle-text',
+					'attributes' => [
+						[
+							'name'               => 'isVisible',
+							'value'              => 'true',
+							'isValueJsonEncoded' => true,
+						],
+						[
+							'name'               => 'isBordered',
+							'value'              => 'false',
+							'isValueJsonEncoded' => true,
+						],
+					],
+				],
+			],
+		];
+
+		$post = $this->factory()->post->create_and_get( [
+			'post_content' => $html,
+		] );
+
+		$blocks_data = GraphQLApi::get_blocks_data( $post );
+
+		$this->assertEquals( $expected_blocks, $blocks_data );
+	}
+
+	public function test_get_block_data_with_number_attributes() {
+		$this->register_global_block_with_attributes( 'test/gallery-block', [
+			'tileCount'   => [
+				'type' => 'number',
+			],
+			'tileWidthPx' => [
+				'type' => 'integer', // Same as 'number'
+			],
+			'tileOpacity' => [
+				'type' => 'number',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/gallery-block { "tileCount": 5, "tileWidthPx": 300, "tileOpacity": 0.5 } -->
+			<div>Gallery</div>
+			<!-- /wp:test/gallery-block -->
+		';
+
+		$expected_blocks = [
+			'blocks' => [
+				[
+					'id'         => '1',
+					'name'       => 'test/gallery-block',
+					'attributes' => [
+						[
+							'name'               => 'tileCount',
+							'value'              => '5',
+							'isValueJsonEncoded' => true,
+						],
+						[
+							'name'               => 'tileWidthPx',
+							'value'              => '300',
+							'isValueJsonEncoded' => true,
+						],
+						[
+							'name'               => 'tileOpacity',
+							'value'              => '0.5',
+							'isValueJsonEncoded' => true,
+						],
+					],
+				],
+			],
+		];
+
+		$post = $this->factory()->post->create_and_get( [
+			'post_content' => $html,
+		] );
+
+		$blocks_data = GraphQLApi::get_blocks_data( $post );
+
+		$this->assertEquals( $expected_blocks, $blocks_data );
+	}
+
+	public function test_get_block_data_with_string_attribute() {
+		$this->register_global_block_with_attributes( 'test/custom-block', [
+			'myComment' => [
+				'type' => 'string',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/custom-block { "myComment": "great!" } -->
+			<p>Toggleable text</p>
+			<!-- /wp:test/custom-block -->
+		';
+
+		$expected_blocks = [
+			'blocks' => [
+				[
+					'id'         => '1',
+					'name'       => 'test/custom-block',
+					'attributes' => [
+						[
+							'name'               => 'myComment',
+							'value'              => 'great!',
+							'isValueJsonEncoded' => false, // Strings should not be marked JSON encoded
+						],
+					],
 				],
 			],
 		];

--- a/tests/mocks/graphql-relay-mock.php
+++ b/tests/mocks/graphql-relay-mock.php
@@ -21,4 +21,8 @@ class Relay {
 		++self::$current_id;
 		return strval( self::$current_id );
 	}
+
+	public static function reset() {
+		self::$current_id = 0;
+	}
 }


### PR DESCRIPTION
## Description

The current implementation of `strval` results in the loss of type information for non-string values. This transformation can lead to unexpected behavior in front-end (FE) applications and may disrupt existing contracts.

The usage of strval on non-string values results in the following conversions:
- `strval(false)` results in `""`
- `strval(true)` results in `"1"`
- `strval(5)` results in `"5"`

Such conversions can alter the original types, potentially causing unforeseen issues in FE applications that rely on precise data types.

This PR introduces a change to encode non-string types as JSON strings. This approach ensures that the original types can be accurately decoded and maintained in FE applications, thereby preserving the expected behavior and integrity of existing contracts.

## Steps to Test

1. Check out PR.
2. Run `composer run test`.

