### PR TITLE
Ensure API returns empty attributes to maintain typing contract integrity

### DIFF
--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -246,6 +246,8 @@ class ContentParser {
 
 			if ( null !== $attribute_value ) {
 				$block_attributes[ $block_attribute_name ] = $attribute_value;
+			} else {
+				$block_attributes[ $block_attribute_name ] = '';
 			}
 		}
 

--- a/tests/graphql/test-graphql-api.php
+++ b/tests/graphql/test-graphql-api.php
@@ -118,6 +118,11 @@ class GraphQLAPITest extends RegistryTestCase {
 							'value'              => '',
 							'isValueJsonEncoded' => false,
 						],
+						[
+							'name'               => 'citation',
+							'value'              => '',
+							'isValueJsonEncoded' => false,
+						],
 					],
 					'innerBlocks' => [
 						[
@@ -141,6 +146,11 @@ class GraphQLAPITest extends RegistryTestCase {
 							'attributes'  => [
 								[
 									'name'               => 'value',
+									'value'              => '',
+									'isValueJsonEncoded' => false,
+								],
+								[
+									'name'               => 'citation',
 									'value'              => '',
 									'isValueJsonEncoded' => false,
 								],


### PR DESCRIPTION
## Description

The current implementation of the content parser doesn't return empty attributes, which is a deviation from the expected behavior. This inconsistency can potentially break the typing contract, causing downstream issues for applications relying on this API.

## Proposed Solution

This pull request addresses the issue by modifying the content parser logic to ensure that empty attributes are included in the response.

## Steps to Test

1. Check out PR.
2. Run `composer run test`.

