### PR TITLE
Add test for default value handling in parser

### DIFF
--- a/tests/parser/test-content-parser.php
+++ b/tests/parser/test-content-parser.php
@@ -113,7 +113,7 @@ class ContentParserTest extends RegistryTestCase {
 				'source'    => 'attribute',
 				'selector'  => 'div',
 				'attribute' => 'data-attr-one',
-				'default'   => '',
+				'default'   => 'Default Attribute 1 Value',
 			],
 			'attributeTwoWithDefaultValueAndNoSource'    => [
 				'type'      => 'string',

--- a/tests/parser/test-content-parser.php
+++ b/tests/parser/test-content-parser.php
@@ -103,4 +103,63 @@ class ContentParserTest extends RegistryTestCase {
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
 	}
+
+	/* Default values and missing values */
+
+	public function test_parse_block_missing_attributes_and_defaults() {
+		$this->register_block_with_attributes( 'test/block-with-empty-attributes', [
+			'attributeOneWithDefaultValueAndSource'      => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'div',
+				'attribute' => 'data-attr-one',
+				'default'   => '',
+			],
+			'attributeTwoWithDefaultValueAndNoSource'    => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'div',
+				'attribute' => 'data-attr-two',
+				'default'   => 'Default Attribute 2 Value',
+			],
+			'attributeThreeWithNoDefaultValueAndSource'  => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'div',
+				'attribute' => 'data-attr-three',
+			],
+			'attributeFourWithNoDefaultValueAndNoSource' => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'div',
+				'attribute' => 'data-attr-four',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/block-with-empty-attributes -->
+			<div
+				data-attr-one="Attribute 1 Value"
+				data-attr-three="Attribute 3 Value"
+			>Content</div>
+			<!-- /wp:test/block-with-empty-attributes -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'test/block-with-empty-attributes',
+				'attributes' => [
+					'attributeOneWithDefaultValueAndSource'   => 'Attribute 1 Value',
+					'attributeTwoWithDefaultValueAndNoSource' => 'Default Attribute 2 Value',
+					'attributeThreeWithNoDefaultValueAndSource' => 'Attribute 3 Value',
+					// attributeFourWithNoDefaultValueAndNoSource has no default, not represented
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->registry );
+		$blocks         = $content_parser->parse( $html );
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
+	}
 }


### PR DESCRIPTION
## Description

See https://github.com/Automattic/vip-block-data-api/pull/67. Currently, when there is no default value available for a block attribute, that attribute is not represented in the block's attribute output.

This PR primarily adds tests to define this behavior as expected, and put it under unit testing.

## Steps to Test

1. Check out PR.
1. Run `wp-env start`
1. Run `composer install`.
1. Run `composer run test`
1. Verify tests pass.

