### PR TITLE
Fix asterisk attribute selector

### DIFF
--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -240,7 +240,7 @@ class ContentParser {
 			$crawler = new Crawler( sprintf( '<!doctype html><html><body>%s</body></html>', $block['innerHTML'] ) );
 
 			// Enter the <body> tag for block parsing.
-			$crawler = $crawler->filter( 'body' );
+			$crawler = $crawler->filter( 'body' )->children();
 
 			$attribute_value = $this->source_attribute( $crawler, $block_attribute_definition );
 
@@ -313,11 +313,11 @@ class ContentParser {
 
 			$attribute_value = $this->source_block_attribute( $crawler, $block_attribute_definition );
 		} elseif ( 'rich-text' === $attribute_source ) {
+			$attribute_value = $this->source_block_rich_text( $crawler, $block_attribute_definition );
+		} elseif ( 'html' === $attribute_source ) {
 			// Most 'html' sources were converted to 'rich-text' in WordPress 6.5.
 			// https://github.com/WordPress/gutenberg/pull/43204
 
-			$attribute_value = $this->source_block_rich_text( $crawler, $block_attribute_definition );
-		} elseif ( 'html' === $attribute_source ) {
 			$attribute_value = $this->source_block_html( $crawler, $block_attribute_definition );
 		} elseif ( 'text' === $attribute_source ) {
 			$attribute_value = $this->source_block_text( $crawler, $block_attribute_definition );
@@ -552,7 +552,7 @@ class ContentParser {
 		$attribute_value = null;
 
 		if ( $crawler->count() > 0 ) {
-			$attribute_value = trim( $crawler->html() );
+			$attribute_value = trim( $crawler->outerHtml() );
 		}
 
 		return $attribute_value;

--- a/tests/parser/sources/test-source-attribute.php
+++ b/tests/parser/sources/test-source-attribute.php
@@ -74,4 +74,35 @@ class SourceAttributeTest extends RegistryTestCase {
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
 	}
+
+	public function test_parse_attribute_source__with_asterisk_selector() {
+		$this->register_block_with_attributes( 'test/image', [
+			'anchor' => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => '*',
+				'attribute' => 'id',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/image -->
+			<img src="/image.jpg" id="anchor123" />
+			<!-- /wp:test/image -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'test/image',
+				'attributes' => [
+					'anchor' => 'anchor123',
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->registry );
+		$blocks         = $content_parser->parse( $html );
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
+	}
 }

--- a/tests/parser/test-content-parser.php
+++ b/tests/parser/test-content-parser.php
@@ -113,7 +113,7 @@ class ContentParserTest extends RegistryTestCase {
 				'source'    => 'attribute',
 				'selector'  => 'div',
 				'attribute' => 'data-attr-one',
-				'default'   => '',
+				'default'   => 'Default Attribute 1 Value',
 			],
 			'attributeTwoWithDefaultValueAndNoSource'    => [
 				'type'      => 'string',

--- a/tests/parser/test-content-parser.php
+++ b/tests/parser/test-content-parser.php
@@ -103,4 +103,63 @@ class ContentParserTest extends RegistryTestCase {
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
 	}
+
+	/* Default values and missing values */
+
+	public function test_parse_block_missing_attributes_and_defaults() {
+		$this->register_block_with_attributes( 'test/block-with-empty-attributes', [
+			'attributeOneWithDefaultValueAndSource'      => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'div',
+				'attribute' => 'data-attr-one',
+				'default'   => '',
+			],
+			'attributeTwoWithDefaultValueAndNoSource'    => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'div',
+				'attribute' => 'data-attr-two',
+				'default'   => 'Default Attribute 2 Value',
+			],
+			'attributeThreeWithNoDefaultValueAndSource'  => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'div',
+				'attribute' => 'data-attr-three',
+			],
+			'attributeFourWithNoDefaultValueAndNoSource' => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'div',
+				'attribute' => 'data-attr-four',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/block-with-empty-attributes -->
+			<div
+				data-attr-one="Attribute 1 Value"
+				data-attr-three="Attribute 3 Value"
+			>Content</div>
+			<!-- /wp:test/block-with-empty-attributes -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'test/block-with-empty-attributes',
+				'attributes' => [
+					'attributeOneWithDefaultValueAndSource'   => 'Attribute 1 Value',
+					'attributeTwoWithDefaultValueAndNoSource' => 'Default Attribute 2 Value',
+					'attributeThreeWithNoDefaultValueAndSource' => 'Attribute 3 Value',
+					// attributeFourWithNoDefaultValueAndNoSource has no default, not represented
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->registry );
+		$blocks         = $content_parser->parse( $html );
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
+	}
 }


### PR DESCRIPTION
## Description

See https://github.com/Automattic/vip-block-data-api/pull/65. When attributes use a `*` selector, this can refer to the wrapping `<body>` element used in the parser and can fail to source attributes correctly.

This PR changes the parser to automatically start with the `children()` of `body` so that the wrapping HTML context is no longer relevant. Note that this also requires the `raw` source to use `outerHtml()` instead of `html()` as the body tag is no longer part of the context. I've tested the `raw` change does not break manual testing with the `core/html` block (at root level and nested), as well as the automated tests already in place.

One new test has been added for the `*` anchor selector case.

## Steps to Test

1. Check out PR.
1. Run `wp-env start`
1. Run `composer install`
1. Run `composer run test`

