### PR TITLE
Add recursive graphql format in blocksDataV2

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,17 +654,22 @@ const blocks = payload.data?.post?.blocksDataV2?.blocks ?? [];
 // Partition blocks by parentId, using 'root' for blocks without a parentId.
 const blocksByParentId = blocks.reduce( ( acc, block ) => {
   const parentId = block.parentId || 'root';
+
+  // Create or append to the array of other blocks sharing this parentId
   acc[ parentId ] = ( acc[ parentId ] || [] ).concat( block );
 
   return acc;
 }, {} );
 
 function addInnerBlocks( block, blocksByParentId ) {
+  // If this block has children:
   if ( block.id in blocksByParentId ) {
+    // Recurse into child blocks and setup their innerBlocks
     let innerBlocks = blocksByParentId[ block.id ].map( innerBlock => {
       return addInnerBlocks( innerBlock, blocksByParentId );
     } );
 
+    // Set the completed innerBlocks on this block
     block.innerBlocks = innerBlocks;
   }
 

--- a/src/graphql/graphql-api-v1.php
+++ b/src/graphql/graphql-api-v1.php
@@ -246,7 +246,7 @@ class GraphQLApiV1 {
 			'blocksData',
 			[
 				'type'        => 'BlocksData',
-				'description' => 'A block representation of post content',
+				'description' => 'Deprecated, prefer blocksDataV2. A block representation of post content.',
 				'resolve'     => [ __CLASS__, 'get_blocks_data' ],
 			]
 		);

--- a/src/graphql/graphql-api-v1.php
+++ b/src/graphql/graphql-api-v1.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * GraphQL API
+ *
+ * @package vip-block-data-api
+ */
+
+namespace WPCOMVIP\BlockDataApi;
+
+use GraphQLRelay\Relay;
+
+defined( 'ABSPATH' ) || die();
+
+/**
+ * GraphQL API to offer an alternative to the REST API.
+ */
+class GraphQLApiV1 {
+	/**
+	 * Initiatilize the graphQL API by hooking into the graphql_register_types action,
+	 * which only fires if WPGraphQL is installed and enabled, and is further controlled
+	 * by the vip_block_data_api__is_graphql_enabled filter.
+	 */
+	public static function init() {
+		add_action( 'graphql_register_types', [ __CLASS__, 'register_types' ] );
+	}
+
+	/**
+	 * Extract the blocks data for a post, and return back in the format expected by the GraphQL API.
+	 *
+	 * @param  \WPGraphQL\Model\Post $post_model Post model for post.
+	 *
+	 * @return array
+	 */
+	public static function get_blocks_data( $post_model ) {
+		$post_id = $post_model->ID;
+		$post    = get_post( $post_id );
+
+		$content_parser = new ContentParser();
+
+		$parser_results = $content_parser->parse( $post->post_content, $post_id );
+
+		// We need to not return a WP_Error object, and so a regular exception is returned.
+		if ( is_wp_error( $parser_results ) ) {
+			Analytics::record_error( $parser_results );
+
+			// Return API-safe error with extra data (e.g. stack trace) removed.
+			return new \Exception( $parser_results->get_error_message() );
+		}
+
+		$parser_results['blocks'] = array_map( function ( $block ) use ( $post_id ) {
+			return self::transform_block_format( $block, $post_id );
+		}, $parser_results['blocks'] );
+
+		return $parser_results;
+	}
+
+	/**
+	 * Transform the block's format to the format expected by the graphQL API.
+	 *
+	 * @param array $block   An associative array of parsed block data with keys 'name' and 'attributes'.
+	 * @param array $post_id The associated post ID for the content being transformed. Used to produce unique block IDs.
+	 *
+	 * @return array
+	 */
+	public static function transform_block_format( $block, $post_id ) {
+		// Generate a unique ID for the block.
+		$block['id'] = Relay::toGlobalId( 'BlockData', sprintf( '%d:%d', $post_id, wp_unique_id() ) );
+
+		// Convert the attributes to be in the name-value format that the schema expects.
+		$block = self::map_attributes( $block );
+
+		if ( isset( $block['innerBlocks'] ) && ! empty( $block['innerBlocks'] ) ) {
+			$block['innerBlocks'] = array_map( function ( $block ) use ( $post_id ) {
+				return self::transform_block_format( $block, $post_id );
+			}, $block['innerBlocks'] );
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Convert the attributes to be in the name-value format that the schema expects.
+	 *
+	 * @param array $block An associative array of parsed block data with keys 'name' and 'attributes'.
+	 *
+	 * @return array
+	 */
+	public static function map_attributes( $block ) {
+		// check if type of attributes is stdClass and unset it as that's not supported by graphQL.
+		if ( isset( $block['attributes'] ) && is_object( $block['attributes'] ) ) {
+			unset( $block['attributes'] );
+		} elseif ( isset( $block['attributes'] ) && ! empty( $block['attributes'] ) ) {
+			$block['attributes'] = array_map(
+				[ __CLASS__, 'get_block_attribute_pair' ],
+				array_keys( $block['attributes'] ),
+				array_values( $block['attributes'] )
+			);
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Flatten the inner blocks, no matter how many levels of nesting is there.
+	 *
+	 * @param array  $inner_blocks the inner blocks in the block.
+	 * @param string $parent_id ID of the parent block, that the inner blocks belong to.
+	 * @param array  $flattened_blocks the flattened blocks that's built up as we go through the inner blocks.
+	 *
+	 * @return array
+	 */
+	public static function flatten_inner_blocks( $inner_blocks, $parent_id, $flattened_blocks = [] ) {
+		foreach ( $inner_blocks as $inner_block ) {
+			// Set the parentId to be the ID of the parent block whose inner blocks are being flattened.
+			$inner_block['parentId'] = $parent_id;
+
+			if ( ! isset( $inner_block['innerBlocks'] ) ) {
+				// This block doesnt have any inner blocks, so just add it to the flattened blocks.
+				array_push( $flattened_blocks, $inner_block );
+			} else {
+				// This block is has inner blocks, so go through the inner blocks recursively.
+				$inner_blocks_copy = $inner_block['innerBlocks'];
+				unset( $inner_block['innerBlocks'] );
+
+				// First add the current block to the flattened blocks, and then go through the inner blocks recursively.
+				array_push( $flattened_blocks, $inner_block );
+				$flattened_blocks = self::flatten_inner_blocks( $inner_blocks_copy, $inner_block['id'], $flattened_blocks );
+			}
+		}
+
+		return $flattened_blocks;
+	}
+
+	/**
+	 * Register types and fields graphql integration.
+	 *
+	 * @return void
+	 */
+	public static function register_types() {
+		/**
+		 * Filter to enable/disable the graphQL API. By default, it is enabled.
+		 *
+		 * @param bool $is_graphql_enabled Whether the graphQL API should be enabled or not.
+		 */
+		$is_graphql_enabled = apply_filters( 'vip_block_data_api__is_graphql_enabled', true );
+
+		if ( ! $is_graphql_enabled ) {
+			return;
+		}
+
+		// Register the type corresponding to the attributes of each individual block.
+		register_graphql_object_type(
+			'BlockAttribute',
+			[
+				'description' => 'Block attribute',
+				'fields'      => [
+					'name'               => [
+						'type'        => [ 'non_null' => 'String' ],
+						'description' => 'Block data attribute name',
+					],
+					'value'              => [
+						'type'        => [ 'non_null' => 'String' ],
+						'description' => 'Block data attribute value',
+					],
+					'isValueJsonEncoded' => [
+						'type'        => [ 'non_null' => 'Boolean' ],
+						'description' => 'True if value is a complex JSON-encoded field. This is used to encode attribute types like arrays and objects.',
+					],
+				],
+			],
+		);
+
+		// Register the type corresponding to the individual block, with the above attribute.
+		register_graphql_type(
+			'BlockData',
+			[
+				'description' => 'Block data',
+				'fields'      => [
+					'id'          => [
+						'type'        => [ 'non_null' => 'ID' ],
+						'description' => 'ID of the block',
+					],
+					'parentId'    => [
+						'type'        => 'ID',
+						'description' => 'ID of the parent for this inner block, if it is an inner block. Otherwise, it will be null.',
+					],
+					'name'        => [
+						'type'        => [ 'non_null' => 'String' ],
+						'description' => 'Block name',
+					],
+					'attributes'  => [
+						'type'        => [
+							'list_of' => 'BlockAttribute',
+						],
+						'description' => 'Block attributes',
+					],
+					'innerBlocks' => [
+						'type'        => [ 'list_of' => 'BlockData' ],
+						'description' => 'Flattened list of inner blocks of this block',
+					],
+				],
+			],
+		);
+
+		// Register the type corresponding to the list of individual blocks, with each item being the above type.
+		register_graphql_type(
+			'BlocksData',
+			[
+				'description' => 'Data for all the blocks',
+				'fields'      => [
+					'blocks'   => [
+						'type'        => [ 'list_of' => 'BlockData' ],
+						'description' => 'List of blocks data',
+						'args'        => [
+							'flatten' => [
+								'type'        => 'Boolean',
+								'description' => 'Collate the inner blocks under each root block into a single list with a parent-child relationship. This is set to true by default, and setting it to false will preserve the original block hierarchy, but will require nested inner block queries to the desired depth. Default: true',
+							],
+						],
+						'resolve'     => function ( $blocks, $args ) {
+							if ( ! isset( $args['flatten'] ) || true === $args['flatten'] ) {
+								$blocks['blocks'] = array_map( function ( $block ) {
+									// Flatten the inner blocks, if any.
+									if ( isset( $block['innerBlocks'] ) ) {
+										$block['innerBlocks'] = self::flatten_inner_blocks( $block['innerBlocks'], $block['id'] );
+									}
+
+									return $block;
+								}, $blocks['blocks'] );
+							}
+
+							return $blocks['blocks'];
+						},
+					],
+					'warnings' => [
+						'type'        => [ 'list_of' => 'String' ],
+						'description' => 'List of warnings related to processing the blocks data',
+					],
+				],
+			],
+		);
+
+		// Register the field on every post type that supports 'editor'.
+		register_graphql_field(
+			'NodeWithContentEditor',
+			'blocksData',
+			[
+				'type'        => 'BlocksData',
+				'description' => 'A block representation of post content',
+				'resolve'     => [ __CLASS__, 'get_blocks_data' ],
+			]
+		);
+	}
+
+	/**
+	 * Given a block attribute name and value, return a BlockAttribute array.
+	 *
+	 * @param string $name The name of the block attribute.
+	 * @param mixed  $value The value of the block attribute.
+	 *
+	 * @return array
+	 */
+	public static function get_block_attribute_pair( $name, $value ) {
+		// Unknown array types (table cells, for example) are encoded as JSON strings.
+		$is_value_json_encoded = false;
+
+		if ( ! is_scalar( $value ) ) {
+			$value                 = wp_json_encode( $value );
+			$is_value_json_encoded = true;
+		}
+
+		return [
+			'name'               => $name,
+			'value'              => strval( $value ),
+			'isValueJsonEncoded' => $is_value_json_encoded,
+		];
+	}
+}
+
+GraphQLApiV1::init();

--- a/src/graphql/graphql-api-v2.php
+++ b/src/graphql/graphql-api-v2.php
@@ -102,11 +102,10 @@ class GraphQLApiV2 {
 	}
 
 	/**
-	 * Flatten the inner blocks, no matter how many levels of nesting is there.
+	 * Flatten blocks recursively.
 	 *
-	 * @param array  $inner_blocks the inner blocks in the block.
-	 * @param string $parent_id ID of the parent block, that the inner blocks belong to.
-	 * @param array  $flattened_blocks the flattened blocks that's built up as we go through the inner blocks.
+	 * @param array  $blocks the inner blocks in the block.
+	 * @param string $parent_id Optional. ID of the parent block that $blocks belong to.
 	 *
 	 * @return array
 	 */

--- a/tests/graphql/test-graphql-api-v1.php
+++ b/tests/graphql/test-graphql-api-v1.php
@@ -1,0 +1,485 @@
+<?php
+/**
+ * Class GraphQLAPITest
+ *
+ * @package vip-block-data-api
+ */
+
+namespace WPCOMVIP\BlockDataApi;
+
+use GraphQLRelay\Relay;
+
+/**
+ * Tests for the GraphQL API.
+ */
+class GraphQLAPIV1Test extends RegistryTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Reset block ID counter before each test
+		Relay::reset();
+	}
+
+	public function test_is_graphql_enabled_true() {
+		$this->assertTrue( apply_filters( 'vip_block_data_api__is_graphql_enabled', true ) );
+	}
+
+	public function test_is_graphql_enabled_false() {
+		$is_graphql_enabled_function = function () {
+			return false;
+		};
+		add_filter( 'vip_block_data_api__is_graphql_enabled', $is_graphql_enabled_function, 10, 0 );
+		$this->assertFalse( apply_filters( 'vip_block_data_api__is_graphql_enabled', true ) );
+		remove_filter( 'vip_block_data_api__is_graphql_enabled', $is_graphql_enabled_function, 10, 0 );
+	}
+
+	// get_blocks_data() tests
+
+	public function test_get_blocks_data() {
+		$this->register_global_block_with_attributes( 'test/custom-paragraph', [
+			'content'     => [
+				'type'               => 'rich-text',
+				'source'             => 'rich-text',
+				'selector'           => 'p',
+				'__experimentalRole' => 'content',
+			],
+			'dropCap'     => [
+				'type'    => 'boolean',
+				'default' => false,
+			],
+			'placeholder' => [
+				'type' => 'string',
+			],
+		] );
+
+		$this->register_global_block_with_attributes( 'test/custom-quote', [
+			'value'    => [
+				'type'               => 'string',
+				'source'             => 'html',
+				'selector'           => 'blockquote',
+				'multiline'          => 'p',
+				'default'            => '',
+				'__experimentalRole' => 'content',
+			],
+			'citation' => [
+				'type'               => 'rich-text',
+				'source'             => 'rich-text',
+				'selector'           => 'cite',
+				'__experimentalRole' => 'content',
+			],
+		] );
+
+		$this->register_global_block_with_attributes( 'test/custom-heading', [
+			'content' => [
+				'type'               => 'rich-text',
+				'source'             => 'rich-text',
+				'selector'           => 'h1,h2,h3,h4,h5,h6',
+				'__experimentalRole' => 'content',
+			],
+			'level'   => [
+				'type'    => 'number',
+				'default' => 2,
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/custom-paragraph -->
+			<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>
+			<!-- /wp:test/custom-paragraph -->
+
+			<!-- wp:test/custom-quote -->
+			<blockquote class="wp-block-quote"><!-- wp:test/custom-paragraph -->
+			<p>This is a heading inside a quote</p>
+			<!-- /wp:test/custom-paragraph -->
+
+			<!-- wp:test/custom-quote -->
+			<blockquote class="wp-block-quote"><!-- wp:test/custom-heading -->
+			<h2 class="wp-block-heading">This is a heading</h2>
+			<!-- /wp:test/custom-heading --></blockquote>
+			<!-- /wp:test/custom-quote --></blockquote>
+			<!-- /wp:test/custom-quote -->
+		';
+
+		$expected_blocks = [
+			'blocks' => [
+				[
+					'name'       => 'test/custom-paragraph',
+					'attributes' => [
+						[
+							'name'               => 'content',
+							'value'              => 'Welcome to WordPress. This is your first post. Edit or delete it, then start writing!',
+							'isValueJsonEncoded' => false,
+						],
+						[
+							'name'               => 'dropCap',
+							'value'              => '',
+							'isValueJsonEncoded' => false,
+						],
+					],
+					'id'         => '1',
+				],
+				[
+					'name'        => 'test/custom-quote',
+					'attributes'  => [
+						[
+							'name'               => 'value',
+							'value'              => '',
+							'isValueJsonEncoded' => false,
+						],
+					],
+					'innerBlocks' => [
+						[
+							'name'       => 'test/custom-paragraph',
+							'attributes' => [
+								[
+									'name'               => 'content',
+									'value'              => 'This is a heading inside a quote',
+									'isValueJsonEncoded' => false,
+								],
+								[
+									'name'               => 'dropCap',
+									'value'              => '',
+									'isValueJsonEncoded' => false,
+								],
+							],
+							'id'         => '3',
+						],
+						[
+							'name'        => 'test/custom-quote',
+							'attributes'  => [
+								[
+									'name'               => 'value',
+									'value'              => '',
+									'isValueJsonEncoded' => false,
+								],
+							],
+							'innerBlocks' => [
+								[
+									'name'       => 'test/custom-heading',
+									'attributes' => [
+										[
+											'name'  => 'content',
+											'value' => 'This is a heading',
+											'isValueJsonEncoded' => false,
+										],
+										[
+											'name'  => 'level',
+											'value' => '2',
+											'isValueJsonEncoded' => false,
+										],
+									],
+									'id'         => '5',
+								],
+							],
+							'id'          => '4',
+						],
+					],
+					'id'          => '2',
+				],
+			],
+		];
+
+		$post = $this->factory()->post->create_and_get( [
+			'post_content' => $html,
+		] );
+
+		$blocks_data = GraphQLApiV1::get_blocks_data( $post );
+
+		$this->assertEquals( $expected_blocks, $blocks_data );
+	}
+
+	// get_blocks_data() attribute type tests
+
+	public function test_array_data_in_attribute() {
+		$this->register_global_block_with_attributes( 'test/custom-table', [
+			'head' => [
+				'type'     => 'array',
+				'default'  => [],
+				'source'   => 'query',
+				'selector' => 'thead tr',
+				'query'    => [
+					'cells' => [
+						'type'     => 'array',
+						'default'  => [],
+						'source'   => 'query',
+						'selector' => 'td,th',
+						'query'    => [
+							'content' => [
+								'type'   => 'rich-text',
+								'source' => 'rich-text',
+							],
+							'tag'     => [
+								'type'    => 'string',
+								'default' => 'td',
+								'source'  => 'tag',
+							],
+						],
+					],
+				],
+			],
+			'body' => [
+				'type'     => 'array',
+				'default'  => [],
+				'source'   => 'query',
+				'selector' => 'tbody tr',
+				'query'    => [
+					'cells' => [
+						'type'     => 'array',
+						'default'  => [],
+						'source'   => 'query',
+						'selector' => 'td,th',
+						'query'    => [
+							'content' => [
+								'type'   => 'rich-text',
+								'source' => 'rich-text',
+							],
+							'tag'     => [
+								'type'    => 'string',
+								'default' => 'td',
+								'source'  => 'tag',
+							],
+						],
+					],
+				],
+			],
+			'foot' => [
+				'type'     => 'array',
+				'default'  => [],
+				'source'   => 'query',
+				'selector' => 'tfoot tr',
+				'query'    => [
+					'cells' => [
+						'type'     => 'array',
+						'default'  => [],
+						'source'   => 'query',
+						'selector' => 'td,th',
+						'query'    => [
+							'content' => [
+								'type'   => 'rich-text',
+								'source' => 'rich-text',
+							],
+							'tag'     => [
+								'type'    => 'string',
+								'default' => 'td',
+								'source'  => 'tag',
+							],
+						],
+					],
+				],
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/custom-table -->
+			<figure class="wp-block-table">
+				<table>
+					<thead>
+						<tr>
+							<th>Header A</th>
+							<th>Header B</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>Value A</td>
+							<td>Value B</td>
+						</tr>
+						<tr>
+							<td>Value C</td>
+							<td>Value D</td>
+						</tr>
+					</tbody>
+					<tfoot>
+						<tr>
+							<td>Footer A</td>
+							<td>Footer B</td>
+						</tr>
+					</tfoot>
+				</table>
+			</figure>
+			<!-- /wp:test/custom-table -->
+		';
+
+		$expected_blocks = [
+			'blocks' => [
+				[
+					'name'       => 'test/custom-table',
+					'attributes' => [
+						[
+							'name'               => 'head',
+							'value'              => '[{"cells":[{"content":"Header A","tag":"th"},{"content":"Header B","tag":"th"}]}]',
+							'isValueJsonEncoded' => true,
+						],
+						[
+							'name'               => 'body',
+							'value'              => '[{"cells":[{"content":"Value A","tag":"td"},{"content":"Value B","tag":"td"}]},{"cells":[{"content":"Value C","tag":"td"},{"content":"Value D","tag":"td"}]}]',
+							'isValueJsonEncoded' => true,
+						],
+						[
+							'name'               => 'foot',
+							'value'              => '[{"cells":[{"content":"Footer A","tag":"td"},{"content":"Footer B","tag":"td"}]}]',
+							'isValueJsonEncoded' => true,
+						],
+					],
+					'id'         => '1',
+				],
+			],
+		];
+
+		$post = $this->factory()->post->create_and_get( [
+			'post_content' => $html,
+		] );
+
+		$blocks_data = GraphQLApiV1::get_blocks_data( $post );
+
+		$this->assertEquals( $expected_blocks, $blocks_data );
+	}
+
+	// flatten_inner_blocks() tests
+
+	public function test_flatten_inner_blocks() {
+		$inner_blocks = [
+			[
+				'name'       => 'core/paragraph',
+				'attributes' => [
+					[
+						'name'  => 'content',
+						'value' => 'Welcome to WordPress. This is your first post. Edit or delete it, then start writing!',
+					],
+					[
+						'name'  => 'dropCap',
+						'value' => '',
+					],
+				],
+				'id'         => '2',
+			],
+			[
+				'name'        => 'core/quote',
+				'attributes'  => [
+					[
+						'name'  => 'value',
+						'value' => '',
+					],
+				],
+				'innerBlocks' => [
+					[
+						'name'       => 'core/paragraph',
+						'attributes' => [
+							[
+								'name'  => 'content',
+								'value' => 'This is a heading inside a quote',
+							],
+							[
+								'name'  => 'dropCap',
+								'value' => '',
+							],
+						],
+						'id'         => '4',
+					],
+					[
+						'name'        => 'core/quote',
+						'attributes'  => [
+							[
+								'name'  => 'value',
+								'value' => '',
+							],
+						],
+						'innerBlocks' => [
+							[
+								'name'       => 'core/heading',
+								'attributes' => [
+									[
+										'name'  => 'content',
+										'value' => 'This is a heading',
+									],
+									[
+										'name'  => 'level',
+										'value' => '2',
+									],
+								],
+								'id'         => '6',
+							],
+						],
+						'id'          => '5',
+					],
+				],
+				'id'          => '3',
+			],
+		];
+
+		$expected_blocks = [
+			[
+				'name'       => 'core/paragraph',
+				'attributes' => [
+					[
+						'name'  => 'content',
+						'value' => 'Welcome to WordPress. This is your first post. Edit or delete it, then start writing!',
+					],
+					[
+						'name'  => 'dropCap',
+						'value' => '',
+					],
+				],
+				'parentId'   => '1',
+				'id'         => '2',
+			],
+			[
+				'name'       => 'core/quote',
+				'attributes' => [
+					[
+						'name'  => 'value',
+						'value' => '',
+					],
+				],
+				'id'         => '3',
+				'parentId'   => '1',
+			],
+			[
+				'name'       => 'core/paragraph',
+				'attributes' => [
+					[
+						'name'  => 'content',
+						'value' => 'This is a heading inside a quote',
+					],
+					[
+						'name'  => 'dropCap',
+						'value' => '',
+					],
+				],
+				'id'         => '4',
+				'parentId'   => '3',
+			],
+			[
+				'name'       => 'core/quote',
+				'attributes' => [
+					[
+						'name'  => 'value',
+						'value' => '',
+					],
+				],
+				'id'         => '5',
+				'parentId'   => '3',
+			],
+			[
+				'name'       => 'core/heading',
+				'attributes' => [
+					[
+						'name'  => 'content',
+						'value' => 'This is a heading',
+					],
+					[
+						'name'  => 'level',
+						'value' => '2',
+					],
+				],
+				'id'         => '6',
+				'parentId'   => '5',
+			],
+		];
+
+		$flattened_blocks = GraphQLApiV1::flatten_inner_blocks( $inner_blocks, '1' );
+
+		$this->assertEquals( $expected_blocks, $flattened_blocks );
+	}
+}

--- a/tests/graphql/test-graphql-api-v2.php
+++ b/tests/graphql/test-graphql-api-v2.php
@@ -12,7 +12,7 @@ use GraphQLRelay\Relay;
 /**
  * Tests for the GraphQL API.
  */
-class GraphQLAPITest extends RegistryTestCase {
+class GraphQLAPIV2Test extends RegistryTestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -105,6 +105,7 @@ class GraphQLAPITest extends RegistryTestCase {
 			'blocks' => [
 				[
 					'name'       => 'test/custom-paragraph',
+					'id'         => '1',
 					'attributes' => [
 						[
 							'name'               => 'content',
@@ -117,10 +118,10 @@ class GraphQLAPITest extends RegistryTestCase {
 							'isValueJsonEncoded' => true,
 						],
 					],
-					'id'         => '1',
 				],
 				[
 					'name'        => 'test/custom-quote',
+					'id'          => '2',
 					'attributes'  => [
 						[
 							'name'               => 'value',
@@ -131,6 +132,7 @@ class GraphQLAPITest extends RegistryTestCase {
 					'innerBlocks' => [
 						[
 							'name'       => 'test/custom-paragraph',
+							'id'         => '3',
 							'attributes' => [
 								[
 									'name'               => 'content',
@@ -143,10 +145,10 @@ class GraphQLAPITest extends RegistryTestCase {
 									'isValueJsonEncoded' => true,
 								],
 							],
-							'id'         => '3',
 						],
 						[
 							'name'        => 'test/custom-quote',
+							'id'          => '4',
 							'attributes'  => [
 								[
 									'name'               => 'value',
@@ -157,6 +159,7 @@ class GraphQLAPITest extends RegistryTestCase {
 							'innerBlocks' => [
 								[
 									'name'       => 'test/custom-heading',
+									'id'         => '5',
 									'attributes' => [
 										[
 											'name'  => 'content',
@@ -169,13 +172,10 @@ class GraphQLAPITest extends RegistryTestCase {
 											'isValueJsonEncoded' => true,
 										],
 									],
-									'id'         => '5',
 								],
 							],
-							'id'          => '4',
 						],
 					],
-					'id'          => '2',
 				],
 			],
 		];
@@ -184,7 +184,7 @@ class GraphQLAPITest extends RegistryTestCase {
 			'post_content' => $html,
 		] );
 
-		$blocks_data = GraphQLApi::get_blocks_data( $post );
+		$blocks_data = GraphQLApiV2::get_blocks_data( $post );
 
 		$this->assertEquals( $expected_blocks, $blocks_data );
 	}
@@ -331,7 +331,7 @@ class GraphQLAPITest extends RegistryTestCase {
 			'post_content' => $html,
 		] );
 
-		$blocks_data = GraphQLApi::get_blocks_data( $post );
+		$blocks_data = GraphQLApiV2::get_blocks_data( $post );
 
 		$this->assertEquals( $expected_blocks, $blocks_data );
 	}
@@ -377,7 +377,7 @@ class GraphQLAPITest extends RegistryTestCase {
 			'post_content' => $html,
 		] );
 
-		$blocks_data = GraphQLApi::get_blocks_data( $post );
+		$blocks_data = GraphQLApiV2::get_blocks_data( $post );
 
 		$this->assertEquals( $expected_blocks, $blocks_data );
 	}
@@ -431,7 +431,7 @@ class GraphQLAPITest extends RegistryTestCase {
 			'post_content' => $html,
 		] );
 
-		$blocks_data = GraphQLApi::get_blocks_data( $post );
+		$blocks_data = GraphQLApiV2::get_blocks_data( $post );
 
 		$this->assertEquals( $expected_blocks, $blocks_data );
 	}
@@ -469,17 +469,18 @@ class GraphQLAPITest extends RegistryTestCase {
 			'post_content' => $html,
 		] );
 
-		$blocks_data = GraphQLApi::get_blocks_data( $post );
+		$blocks_data = GraphQLApiV2::get_blocks_data( $post );
 
 		$this->assertEquals( $expected_blocks, $blocks_data );
 	}
 
-	// flatten_inner_blocks() tests
+	// flatten_blocks() tests
 
-	public function test_flatten_inner_blocks() {
-		$inner_blocks = [
+	public function test_flatten_blocks() {
+		$blocks = [
 			[
 				'name'       => 'core/paragraph',
+				'id'         => '1',
 				'attributes' => [
 					[
 						'name'  => 'content',
@@ -490,10 +491,10 @@ class GraphQLAPITest extends RegistryTestCase {
 						'value' => '',
 					],
 				],
-				'id'         => '2',
 			],
 			[
 				'name'        => 'core/quote',
+				'id'          => '2',
 				'attributes'  => [
 					[
 						'name'  => 'value',
@@ -503,6 +504,7 @@ class GraphQLAPITest extends RegistryTestCase {
 				'innerBlocks' => [
 					[
 						'name'       => 'core/paragraph',
+						'id'         => '3',
 						'attributes' => [
 							[
 								'name'  => 'content',
@@ -513,10 +515,10 @@ class GraphQLAPITest extends RegistryTestCase {
 								'value' => '',
 							],
 						],
-						'id'         => '4',
 					],
 					[
 						'name'        => 'core/quote',
+						'id'          => '4',
 						'attributes'  => [
 							[
 								'name'  => 'value',
@@ -526,6 +528,7 @@ class GraphQLAPITest extends RegistryTestCase {
 						'innerBlocks' => [
 							[
 								'name'       => 'core/heading',
+								'id'         => '5',
 								'attributes' => [
 									[
 										'name'  => 'content',
@@ -536,13 +539,10 @@ class GraphQLAPITest extends RegistryTestCase {
 										'value' => '2',
 									],
 								],
-								'id'         => '6',
 							],
 						],
-						'id'          => '5',
 					],
 				],
-				'id'          => '3',
 			],
 		];
 
@@ -559,8 +559,8 @@ class GraphQLAPITest extends RegistryTestCase {
 						'value' => '',
 					],
 				],
-				'parentId'   => '1',
-				'id'         => '2',
+				'parentId'   => null,
+				'id'         => '1',
 			],
 			[
 				'name'       => 'core/quote',
@@ -570,8 +570,8 @@ class GraphQLAPITest extends RegistryTestCase {
 						'value' => '',
 					],
 				],
-				'id'         => '3',
-				'parentId'   => '1',
+				'id'         => '2',
+				'parentId'   => null,
 			],
 			[
 				'name'       => 'core/paragraph',
@@ -585,8 +585,8 @@ class GraphQLAPITest extends RegistryTestCase {
 						'value' => '',
 					],
 				],
-				'id'         => '4',
-				'parentId'   => '3',
+				'id'         => '3',
+				'parentId'   => '2',
 			],
 			[
 				'name'       => 'core/quote',
@@ -596,8 +596,8 @@ class GraphQLAPITest extends RegistryTestCase {
 						'value' => '',
 					],
 				],
-				'id'         => '5',
-				'parentId'   => '3',
+				'id'         => '4',
+				'parentId'   => '2',
 			],
 			[
 				'name'       => 'core/heading',
@@ -611,12 +611,12 @@ class GraphQLAPITest extends RegistryTestCase {
 						'value' => '2',
 					],
 				],
-				'id'         => '6',
-				'parentId'   => '5',
+				'id'         => '5',
+				'parentId'   => '4',
 			],
 		];
 
-		$flattened_blocks = GraphQLApi::flatten_inner_blocks( $inner_blocks, '1' );
+		$flattened_blocks = GraphQLApiV2::flatten_blocks( $blocks );
 
 		$this->assertEquals( $expected_blocks, $flattened_blocks );
 	}

--- a/tests/graphql/test-graphql-api-v2.php
+++ b/tests/graphql/test-graphql-api-v2.php
@@ -106,6 +106,7 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 				[
 					'name'       => 'test/custom-paragraph',
 					'id'         => '1',
+					'parentId'   => null,
 					'attributes' => [
 						[
 							'name'               => 'content',
@@ -120,60 +121,60 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 					],
 				],
 				[
-					'name'        => 'test/custom-quote',
-					'id'          => '2',
-					'attributes'  => [
+					'name'       => 'test/custom-quote',
+					'id'         => '2',
+					'parentId'   => null,
+					'attributes' => [
 						[
 							'name'               => 'value',
 							'value'              => '',
 							'isValueJsonEncoded' => false,
 						],
 					],
-					'innerBlocks' => [
+				],
+				[
+					'name'       => 'test/custom-paragraph',
+					'id'         => '3',
+					'parentId'   => '2',
+					'attributes' => [
 						[
-							'name'       => 'test/custom-paragraph',
-							'id'         => '3',
-							'attributes' => [
-								[
-									'name'               => 'content',
-									'value'              => 'This is a heading inside a quote',
-									'isValueJsonEncoded' => false,
-								],
-								[
-									'name'               => 'dropCap',
-									'value'              => 'false',
-									'isValueJsonEncoded' => true,
-								],
-							],
+							'name'               => 'content',
+							'value'              => 'This is a heading inside a quote',
+							'isValueJsonEncoded' => false,
 						],
 						[
-							'name'        => 'test/custom-quote',
-							'id'          => '4',
-							'attributes'  => [
-								[
-									'name'               => 'value',
-									'value'              => '',
-									'isValueJsonEncoded' => false,
-								],
-							],
-							'innerBlocks' => [
-								[
-									'name'       => 'test/custom-heading',
-									'id'         => '5',
-									'attributes' => [
-										[
-											'name'  => 'content',
-											'value' => 'This is a heading',
-											'isValueJsonEncoded' => false,
-										],
-										[
-											'name'  => 'level',
-											'value' => '2',
-											'isValueJsonEncoded' => true,
-										],
-									],
-								],
-							],
+							'name'               => 'dropCap',
+							'value'              => 'false',
+							'isValueJsonEncoded' => true,
+						],
+					],
+				],
+				[
+					'name'       => 'test/custom-quote',
+					'id'         => '4',
+					'parentId'   => '2',
+					'attributes' => [
+						[
+							'name'               => 'value',
+							'value'              => '',
+							'isValueJsonEncoded' => false,
+						],
+					],
+				],
+				[
+					'name'       => 'test/custom-heading',
+					'id'         => '5',
+					'parentId'   => '4',
+					'attributes' => [
+						[
+							'name'               => 'content',
+							'value'              => 'This is a heading',
+							'isValueJsonEncoded' => false,
+						],
+						[
+							'name'               => 'level',
+							'value'              => '2',
+							'isValueJsonEncoded' => true,
 						],
 					],
 				],
@@ -305,6 +306,8 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 			'blocks' => [
 				[
 					'name'       => 'test/custom-table',
+					'id'         => '1',
+					'parentId'   => null,
 					'attributes' => [
 						[
 							'name'               => 'head',
@@ -322,7 +325,6 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 							'isValueJsonEncoded' => true,
 						],
 					],
-					'id'         => '1',
 				],
 			],
 		];
@@ -356,6 +358,7 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 			'blocks' => [
 				[
 					'id'         => '1',
+					'parentId'   => null,
 					'name'       => 'test/toggle-text',
 					'attributes' => [
 						[
@@ -405,6 +408,7 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 			'blocks' => [
 				[
 					'id'         => '1',
+					'parentId'   => null,
 					'name'       => 'test/gallery-block',
 					'attributes' => [
 						[
@@ -453,6 +457,7 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 			'blocks' => [
 				[
 					'id'         => '1',
+					'parentId'   => null,
 					'name'       => 'test/custom-block',
 					'attributes' => [
 						[

--- a/vip-block-data-api.php
+++ b/vip-block-data-api.php
@@ -32,7 +32,8 @@ if ( ! defined( 'VIP_BLOCK_DATA_API_LOADED' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
 
 	// GraphQL API.
-	require_once __DIR__ . '/src/graphql/graphql-api.php';
+	require_once __DIR__ . '/src/graphql/graphql-api-v1.php';
+	require_once __DIR__ . '/src/graphql/graphql-api-v2.php';
 
 	// /wp-json/ API.
 	require_once __DIR__ . '/src/rest/rest-api.php';


### PR DESCRIPTION
## Description

Recently, data type representations were changed in https://github.com/Automattic/vip-block-data-api/pull/66 which modified some odd parsing results when consuming GraphQL:

> - `strval(false)` results in `""`
> - `strval(true)` results in `"1"`
> - `strval(5)` results in `"5"`

This behavior has been fixed in the development branch (`planned-release/1.3.0`), but it causes a breaking change to GraphQL attribute data. If other customers rely on the old behavior (e.g. `false == ""`), we don't want to unexpectedly change data reprentation. Because of this, we decided to split these changes into a new `blocksDataV2` GraphQL variable to avoid breaking any dependencies on the previous behavior.

## Recursive block structure

This PR also changes the structure of block data, preferring a flattened, recursive structure by default. To show the difference, here was a prior query to get all blocks (and their inner blocks) with full attributes:

```graphql
query OldQuery {
  post(id: 1, idType: DATABASE_ID) {
    blocksData {
      blocks {
        attributes {
          name
          value
          isValueJsonEncoded
        }
        id
        name
        innerBlocks {
          attributes {
            name
            value
            isValueJsonEncoded
          }
          id
          name
          parentId
        }
      }
    }
  }
}
```

There's some repetition - `innerBlocks` is basically the same query as `blocks`, but it must be specified separately with a `parentId`. `attributes`' properties must also be repeated in both sections. Here is the new query:

```graphql
query NewQuery {
  post(id: 1, idType: DATABASE_ID) {
    blocksDataV2 {
      blocks {
        name
        id
        parentId
        attributes {
          name
          value
          isValueJsonEncoded
        }
      }
    }
  }
}
```

This query will return every block, including inner blocks, as a flattened structure. Each block has a queryable `parentId` and both root and inner blocks are returned in the same structure. Root blocks will have a `null` `parentId`, and non-root blocks will have a specified `parentId`. The `flatten` option (default `true`) was also removed, and every `blocksDataV2` query will return flattened data.

For an example of the output in the new format, see [**Example: Simple nested blocks: `core/list` and `core/quote`** in the updated README](https://github.com/Automattic/vip-block-data-api/blob/d02658fe743e3a298d62fa9b0a16653acb400812/README.md#example-simple-nested-blocks-corelist-and-corequote) or the [block reconstruction example](https://github.com/Automattic/vip-block-data-api/blob/d02658fe743e3a298d62fa9b0a16653acb400812/README.md#example) in this branch.

## Block reconstruction

Another benefit of the new recursive structure is that block reconstruction code has been simplified. [Old block reconstruction code](https://github.com/Automattic/vip-block-data-api/blob/1.2.4/README.md#block-hierarchy-reconstruction) was more complex as it needed to handle outer and inner block processing separately due to their different data structures. The [new reconstruction code example](https://github.com/Automattic/vip-block-data-api/blob/d02658fe743e3a298d62fa9b0a16653acb400812/README.md#block-hierarchy-reconstruction) is shorter and simpler.

## Other changes

The changes that were made in https://github.com/Automattic/vip-block-data-api/pull/66 to `blocksData` and related tests have been moved to `blocksDataV2` and new test files instead. The `blocksData` (v1) property has been modified to include a deprecated notice in the description, but otherwise will remain unchanged for any plugin users that rely on the prior structure or data representation.

## Steps to Test

Automated tests:

1. Check out PR.
2. Run `wp-env start`
3. Run `composer install`
4. Run `composer run test`

Manual tests:

1. Install this PR's branch (`add/recursive-graphql-format`) on a WordPress site.
2. Also ensure the WPGraphQL plugin is installed on the same site.
3. Create a post with nested data, e.g.

    ```html
    <!-- wp:columns -->
    <div class="wp-block-columns">
        <!-- wp:column -->
        <div class="wp-block-column">
            <!-- wp:paragraph -->
            <p>Left column</p>
            <!-- /wp:paragraph -->
        </div>
        <!-- /wp:column -->

        <!-- wp:column -->
        <div class="wp-block-column">
            <!-- wp:paragraph -->
            <p>Right column</p>
            <!-- /wp:paragraph -->
        </div>
        <!-- /wp:column -->
    </div>
    <!-- /wp:columns -->
    ```

5. In the WordPress admin, go to GraphQL -> GraphQL IDE.
6. Run this query, replacing `<post-id>` with the relevant post ID from step 4:

    ```
    query PostQuery {
      post(id: <post-id>, idType: DATABASE_ID) {
        blocksDataV2 {
          blocks {
            name
            id
            parentId
            attributes {
              name
              value
            }
          }
        }
      }
    }
    ```

7. View the result. The data should contain each block in a flattened list, with `parentIds` corresponding the nested structure of the post:

    ```json
    {
      "data": {
        "post": {
          "blocksDataV2": {
            "blocks": [
              {
                "name": "core/columns",
                "id": "QmxvY2tEYXRhVjI6NDY6MQ==",
                "parentId": null,
                "attributes": [
                  {
                    "name": "isStackedOnMobile",
                    "value": "true"
                  }
                ]
              },
              {
                "name": "core/column",
                "id": "QmxvY2tEYXRhVjI6NDY6Mg==",
                "parentId": "QmxvY2tEYXRhVjI6NDY6MQ==",
                "attributes": null
              },
              {
                "name": "core/paragraph",
                "id": "QmxvY2tEYXRhVjI6NDY6Mw==",
                "parentId": "QmxvY2tEYXRhVjI6NDY6Mg==",
                "attributes": [
                  {
                    "name": "content",
                    "value": "Left column"
                  },
                  {
                    "name": "dropCap",
                    "value": "false"
                  }
                ]
              },
              {
                "name": "core/column",
                "id": "QmxvY2tEYXRhVjI6NDY6NA==",
                "parentId": "QmxvY2tEYXRhVjI6NDY6MQ==",
                "attributes": null
              },
              {
                "name": "core/paragraph",
                "id": "QmxvY2tEYXRhVjI6NDY6NQ==",
                "parentId": "QmxvY2tEYXRhVjI6NDY6NA==",
                "attributes": [
                  {
                    "name": "content",
                    "value": "Right column"
                  },
                  {
                    "name": "dropCap",
                    "value": "false"
                  }
                ]
              }
            ]
          }
        }
      }
    }
    ```