### PR TITLE
Add block binding support

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -46,7 +46,7 @@
 	<rule ref="WordPress-Extra"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.9"/>
+	<config name="minimum_supported_wp_version" value="6.0"/>
 
 	<rule ref="WordPress-VIP-Go">
 		<!-- These disallow anonymous functions as action callbacks -->

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -252,9 +252,9 @@ class ContentParser {
 		$inner_blocks = iterator_to_array( $block->inner_blocks );
 
 		// Recursively iterate over inner blocks.
-		$sourced_inner_blocks = array_filter( array_map( function ( $inner_block ) use ( $filter_options ) {
+		$sourced_inner_blocks = array_values( array_filter( array_map( function ( $inner_block ) use ( $filter_options ) {
 			return $this->source_block( $inner_block, $filter_options );
-		}, $inner_blocks ) );
+		}, $inner_blocks ) ) );
 
 		// This empty check is not strictly necessary, but previous versions did
 		// not set innerBlocks if the array was empty.

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -256,8 +256,7 @@ class ContentParser {
 			return $this->source_block( $inner_block, $filter_options );
 		}, $inner_blocks ) ) );
 
-		// This empty check is not strictly necessary, but previous versions did
-		// not set innerBlocks if the array was empty.
+		// Only set innerBlocks if entries are present to match prior version behavior.
 		if ( ! empty( $sourced_inner_blocks ) ) {
 			$sourced_block['innerBlocks'] = $sourced_inner_blocks;
 		}

--- a/tests/graphql/test-graphql-api-v1.php
+++ b/tests/graphql/test-graphql-api-v1.php
@@ -307,11 +307,6 @@ class GraphQLAPIV1Test extends RegistryTestCase {
 					'name'       => 'test/custom-table',
 					'attributes' => [
 						[
-							'name'               => 'head',
-							'value'              => '[{"cells":[{"content":"Header A","tag":"th"},{"content":"Header B","tag":"th"}]}]',
-							'isValueJsonEncoded' => true,
-						],
-						[
 							'name'               => 'body',
 							'value'              => '[{"cells":[{"content":"Value A","tag":"td"},{"content":"Value B","tag":"td"}]},{"cells":[{"content":"Value C","tag":"td"},{"content":"Value D","tag":"td"}]}]',
 							'isValueJsonEncoded' => true,
@@ -319,6 +314,11 @@ class GraphQLAPIV1Test extends RegistryTestCase {
 						[
 							'name'               => 'foot',
 							'value'              => '[{"cells":[{"content":"Footer A","tag":"td"},{"content":"Footer B","tag":"td"}]}]',
+							'isValueJsonEncoded' => true,
+						],
+						[
+							'name'               => 'head',
+							'value'              => '[{"cells":[{"content":"Header A","tag":"th"},{"content":"Header B","tag":"th"}]}]',
 							'isValueJsonEncoded' => true,
 						],
 					],

--- a/tests/graphql/test-graphql-api-v1.php
+++ b/tests/graphql/test-graphql-api-v1.php
@@ -37,7 +37,7 @@ class GraphQLAPIV1Test extends RegistryTestCase {
 	// get_blocks_data() tests
 
 	public function test_get_blocks_data() {
-		$this->register_global_block_with_attributes( 'test/custom-paragraph', [
+		$this->register_block_with_attributes( 'test/custom-paragraph', [
 			'content'     => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -53,7 +53,7 @@ class GraphQLAPIV1Test extends RegistryTestCase {
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-quote', [
+		$this->register_block_with_attributes( 'test/custom-quote', [
 			'value'    => [
 				'type'               => 'string',
 				'source'             => 'html',
@@ -70,7 +70,7 @@ class GraphQLAPIV1Test extends RegistryTestCase {
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-heading', [
+		$this->register_block_with_attributes( 'test/custom-heading', [
 			'content' => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -192,7 +192,7 @@ class GraphQLAPIV1Test extends RegistryTestCase {
 	// get_blocks_data() attribute type tests
 
 	public function test_array_data_in_attribute() {
-		$this->register_global_block_with_attributes( 'test/custom-table', [
+		$this->register_block_with_attributes( 'test/custom-table', [
 			'head' => [
 				'type'     => 'array',
 				'default'  => [],

--- a/tests/graphql/test-graphql-api-v2.php
+++ b/tests/graphql/test-graphql-api-v2.php
@@ -310,11 +310,6 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 					'parentId'   => null,
 					'attributes' => [
 						[
-							'name'               => 'head',
-							'value'              => '[{"cells":[{"content":"Header A","tag":"th"},{"content":"Header B","tag":"th"}]}]',
-							'isValueJsonEncoded' => true,
-						],
-						[
 							'name'               => 'body',
 							'value'              => '[{"cells":[{"content":"Value A","tag":"td"},{"content":"Value B","tag":"td"}]},{"cells":[{"content":"Value C","tag":"td"},{"content":"Value D","tag":"td"}]}]',
 							'isValueJsonEncoded' => true,
@@ -322,6 +317,11 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 						[
 							'name'               => 'foot',
 							'value'              => '[{"cells":[{"content":"Footer A","tag":"td"},{"content":"Footer B","tag":"td"}]}]',
+							'isValueJsonEncoded' => true,
+						],
+						[
+							'name'               => 'head',
+							'value'              => '[{"cells":[{"content":"Header A","tag":"th"},{"content":"Header B","tag":"th"}]}]',
 							'isValueJsonEncoded' => true,
 						],
 					],
@@ -362,13 +362,13 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 					'name'       => 'test/toggle-text',
 					'attributes' => [
 						[
-							'name'               => 'isVisible',
-							'value'              => 'true',
+							'name'               => 'isBordered',
+							'value'              => 'false',
 							'isValueJsonEncoded' => true,
 						],
 						[
-							'name'               => 'isBordered',
-							'value'              => 'false',
+							'name'               => 'isVisible',
+							'value'              => 'true',
 							'isValueJsonEncoded' => true,
 						],
 					],
@@ -417,13 +417,13 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 							'isValueJsonEncoded' => true,
 						],
 						[
-							'name'               => 'tileWidthPx',
-							'value'              => '300',
+							'name'               => 'tileOpacity',
+							'value'              => '0.5',
 							'isValueJsonEncoded' => true,
 						],
 						[
-							'name'               => 'tileOpacity',
-							'value'              => '0.5',
+							'name'               => 'tileWidthPx',
+							'value'              => '300',
 							'isValueJsonEncoded' => true,
 						],
 					],

--- a/tests/graphql/test-graphql-api-v2.php
+++ b/tests/graphql/test-graphql-api-v2.php
@@ -37,7 +37,7 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 	// get_blocks_data() tests
 
 	public function test_get_blocks_data() {
-		$this->register_global_block_with_attributes( 'test/custom-paragraph', [
+		$this->register_block_with_attributes( 'test/custom-paragraph', [
 			'content'     => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -53,7 +53,7 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-quote', [
+		$this->register_block_with_attributes( 'test/custom-quote', [
 			'value'    => [
 				'type'               => 'string',
 				'source'             => 'html',
@@ -70,7 +70,7 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-heading', [
+		$this->register_block_with_attributes( 'test/custom-heading', [
 			'content' => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -193,7 +193,7 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 	// get_blocks_data() attribute type tests
 
 	public function test_array_data_in_attribute() {
-		$this->register_global_block_with_attributes( 'test/custom-table', [
+		$this->register_block_with_attributes( 'test/custom-table', [
 			'head' => [
 				'type'     => 'array',
 				'default'  => [],
@@ -339,7 +339,7 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 	}
 
 	public function test_get_block_data_with_boolean_attributes() {
-		$this->register_global_block_with_attributes( 'test/toggle-text', [
+		$this->register_block_with_attributes( 'test/toggle-text', [
 			'isVisible'  => [
 				'type' => 'boolean',
 			],
@@ -386,7 +386,7 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 	}
 
 	public function test_get_block_data_with_number_attributes() {
-		$this->register_global_block_with_attributes( 'test/gallery-block', [
+		$this->register_block_with_attributes( 'test/gallery-block', [
 			'tileCount'   => [
 				'type' => 'number',
 			],
@@ -441,7 +441,7 @@ class GraphQLAPIV2Test extends RegistryTestCase {
 	}
 
 	public function test_get_block_data_with_string_attribute() {
-		$this->register_global_block_with_attributes( 'test/custom-block', [
+		$this->register_block_with_attributes( 'test/custom-block', [
 			'myComment' => [
 				'type' => 'string',
 			],

--- a/tests/parser/blocks/test-unregistered-block.php
+++ b/tests/parser/blocks/test-unregistered-block.php
@@ -31,7 +31,7 @@ class UnregisteredBlockTest extends RegistryTestCase {
 			'Block type "test/unknown-block" is not server-side registered. Sourced block attributes will not be available.',
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArrayHasKey( 'warnings', $blocks, sprintf( 'Expected parser to have warnings, none received: %s', wp_json_encode( $blocks ) ) );

--- a/tests/parser/sources/test-source-attribute.php
+++ b/tests/parser/sources/test-source-attribute.php
@@ -37,7 +37,7 @@ class SourceAttributeTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -69,7 +69,7 @@ class SourceAttributeTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -100,7 +100,7 @@ class SourceAttributeTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );

--- a/tests/parser/sources/test-source-children.php
+++ b/tests/parser/sources/test-source-children.php
@@ -52,7 +52,7 @@ class ChildrenSourceTest extends RegistryTestCase {
 			],
 		];
 
-			$content_parser = new ContentParser( $this->registry );
+			$content_parser = new ContentParser( $this->get_block_registry() );
 			$blocks         = $content_parser->parse( $html );
 			$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 			$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -86,7 +86,7 @@ class ChildrenSourceTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -126,7 +126,7 @@ class ChildrenSourceTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -157,7 +157,7 @@ class ChildrenSourceTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );

--- a/tests/parser/sources/test-source-delimiter.php
+++ b/tests/parser/sources/test-source-delimiter.php
@@ -45,7 +45,7 @@ class DelimiterSourceTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -75,7 +75,7 @@ class DelimiterSourceTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );

--- a/tests/parser/sources/test-source-html.php
+++ b/tests/parser/sources/test-source-html.php
@@ -36,7 +36,7 @@ class SourceHtmlTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -71,7 +71,7 @@ class SourceHtmlTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -102,7 +102,7 @@ class SourceHtmlTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );

--- a/tests/parser/sources/test-source-meta.php
+++ b/tests/parser/sources/test-source-meta.php
@@ -39,7 +39,7 @@ class SourceMetaTest extends RegistryTestCase {
 			return $post_id;
 		};
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html, $post_id );
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
@@ -69,7 +69,7 @@ class SourceMetaTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html, $post_id );
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );

--- a/tests/parser/sources/test-source-node.php
+++ b/tests/parser/sources/test-source-node.php
@@ -43,7 +43,7 @@ class NodeSourceTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );

--- a/tests/parser/sources/test-source-query.php
+++ b/tests/parser/sources/test-source-query.php
@@ -59,7 +59,7 @@ class SourceQueryTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
@@ -145,7 +145,7 @@ class SourceQueryTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
@@ -193,7 +193,7 @@ class SourceQueryTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );

--- a/tests/parser/sources/test-source-raw.php
+++ b/tests/parser/sources/test-source-raw.php
@@ -33,7 +33,7 @@ class SourceRawTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -74,7 +74,7 @@ class SourceRawTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );

--- a/tests/parser/sources/test-source-rich-text.php
+++ b/tests/parser/sources/test-source-rich-text.php
@@ -36,7 +36,7 @@ class SourceRichTextTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -69,7 +69,7 @@ class SourceRichTextTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -100,7 +100,7 @@ class SourceRichTextTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -131,7 +131,7 @@ class SourceRichTextTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );

--- a/tests/parser/sources/test-source-tag.php
+++ b/tests/parser/sources/test-source-tag.php
@@ -35,7 +35,7 @@ class SourceTagTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -79,7 +79,7 @@ class SourceTagTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -106,7 +106,7 @@ class SourceTagTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );

--- a/tests/parser/sources/test-source-text.php
+++ b/tests/parser/sources/test-source-text.php
@@ -38,7 +38,7 @@ class SourceTextTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -72,7 +72,7 @@ class SourceTextTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -104,7 +104,7 @@ class SourceTextTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );

--- a/tests/parser/test-block-bindings.php
+++ b/tests/parser/test-block-bindings.php
@@ -54,4 +54,63 @@ class BlockBindingsTest extends RegistryTestCase {
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
 	}
+
+	/* Nested paragraph block binding with context */
+
+	public function test_nested_paragraph_block_binding_with_custom_context() {
+		$this->register_block_bindings_source(
+			'test/block-binding-with-custom-context', [
+				'label'              => 'Test paragraph block binding with custom context',
+				'get_value_callback' => static function ( array $args, WP_Block $block ) {
+					return sprintf( 'Block binding for %s with arg foo=%s and context fizz=%s', $block->name, $args['foo'], $block->context['my-context/fizz'] ?? 'missing' );
+				},
+				'uses_context'       => [ 'my-context/fizz' ],
+			]
+		);
+
+		$this->register_block_with_attributes(
+			'test/context-provider',
+			[
+				'fizz' => [
+					'type' => 'string',
+				],
+			],
+			[
+				'provides_context' => [
+					'my-context/fizz' => 'fizz',
+				],
+			]
+		);
+
+		$html = '
+		<!-- wp:test/context-provider {"fizz":"buzz"} -->
+		<!-- wp:core/paragraph {"metadata":{"bindings":{"content":{"source":"test/block-binding-with-custom-context","args":{"foo":"bar"}}}}} -->
+		<p>Fallback content</p>
+		<!-- /wp:core/paragraph -->
+		<!-- /wp:test/context-provider -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'        => 'test/context-provider',
+				'attributes'  => [
+					'fizz' => 'buzz',
+				],
+				'innerBlocks' => [
+					[
+						'name'       => 'core/paragraph',
+						'attributes' => [
+							'content' => 'Block binding for core/paragraph with arg foo=bar and context fizz=buzz',
+						],
+					],
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
+	}
 }

--- a/tests/parser/test-block-bindings.php
+++ b/tests/parser/test-block-bindings.php
@@ -8,6 +8,7 @@
 namespace WPCOMVIP\BlockDataApi;
 
 use WP_Block;
+use function version_compare;
 
 /**
  * Test parsing blocks with block binding.
@@ -15,6 +16,10 @@ use WP_Block;
 class BlockBindingsTest extends RegistryTestCase {
 	protected function setUp(): void {
 		parent::setUp();
+
+		if ( version_compare( $GLOBALS['wp_version'], '6.5.0', '<' ) ) {
+			$this->markTestSkipped( 'This test suite requires WordPress 6.5 or higher.' );
+		}
 
 		$this->ensure_core_blocks_are_registered();
 	}

--- a/tests/parser/test-block-bindings.php
+++ b/tests/parser/test-block-bindings.php
@@ -198,4 +198,30 @@ class BlockBindingsTest extends RegistryTestCase {
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
 	}
+
+	/* Missing block binding */
+
+	public function test_missing_block_binding() {
+
+		$html = '
+			<!-- wp:core/paragraph {"metadata":{"bindings":{"content":{"source":"test/missing-block-binding","args":{"foo":"bar"}}}}} -->
+			<p>Fallback content</p>
+			<!-- /wp:core/paragraph -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'core/paragraph',
+				'attributes' => [
+					'content' => 'Fallback content',
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
+	}
 }

--- a/tests/parser/test-block-bindings.php
+++ b/tests/parser/test-block-bindings.php
@@ -8,7 +8,6 @@
 namespace WPCOMVIP\BlockDataApi;
 
 use WP_Block;
-use function version_compare;
 
 /**
  * Test parsing blocks with block binding.
@@ -20,8 +19,6 @@ class BlockBindingsTest extends RegistryTestCase {
 		if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
 			$this->markTestSkipped( 'This test suite requires WP_Block_Bindings_Registry (WordPress 6.5 or higher).' );
 		}
-
-		$this->ensure_core_blocks_are_registered();
 	}
 
 	/* Single paragraph block binding */

--- a/tests/parser/test-block-bindings.php
+++ b/tests/parser/test-block-bindings.php
@@ -122,7 +122,7 @@ class BlockBindingsTest extends RegistryTestCase {
 		<!-- /wp:core/paragraph -->
 		';
 
-		$post = $this->factory->post->create_and_get();
+		$post = $this->factory()->post->create_and_get();
 
 		$expected_blocks = [
 			[

--- a/tests/parser/test-block-bindings.php
+++ b/tests/parser/test-block-bindings.php
@@ -45,7 +45,15 @@ class BlockBindingsTest extends RegistryTestCase {
 			[
 				'name'       => 'core/paragraph',
 				'attributes' => [
-					'content' => 'Block binding for core/paragraph with arg foo=bar',
+					'content'  => 'Block binding for core/paragraph with arg foo=bar',
+					'metadata' => [
+						'bindings' => [
+							'content' => [
+								'source' => 'test/block-binding',
+								'args'   => [ 'foo' => 'bar' ],
+							],
+						],
+					],
 				],
 			],
 		];
@@ -136,7 +144,15 @@ class BlockBindingsTest extends RegistryTestCase {
 			[
 				'name'       => 'core/paragraph',
 				'attributes' => [
-					'content' => sprintf( 'Block binding for core/paragraph with arg foo=bar in post %d', $post->ID ),
+					'content'  => sprintf( 'Block binding for core/paragraph with arg foo=bar in post %d', $post->ID ),
+					'metadata' => [
+						'bindings' => [
+							'content' => [
+								'source' => 'test/block-binding-with-default-context',
+								'args'   => [ 'foo' => 'bar' ],
+							],
+						],
+					],
 				],
 			],
 		];
@@ -197,7 +213,15 @@ class BlockBindingsTest extends RegistryTestCase {
 					[
 						'name'       => 'core/paragraph',
 						'attributes' => [
-							'content' => 'Block binding for core/paragraph with arg foo=bar and context fizz=buzz',
+							'content'  => 'Block binding for core/paragraph with arg foo=bar and context fizz=buzz',
+							'metadata' => [
+								'bindings' => [
+									'content' => [
+										'source' => 'test/block-binding-with-custom-context',
+										'args'   => [ 'foo' => 'bar' ],
+									],
+								],
+							],
 						],
 					],
 				],
@@ -230,7 +254,15 @@ class BlockBindingsTest extends RegistryTestCase {
 			[
 				'name'       => 'core/paragraph',
 				'attributes' => [
-					'content' => 'Fallback content',
+					'content'  => 'Fallback content',
+					'metadata' => [
+						'bindings' => [
+							'content' => [
+								'source' => 'test/missing-block-binding',
+								'args'   => [ 'foo' => 'bar' ],
+							],
+						],
+					],
 				],
 			],
 		];

--- a/tests/parser/test-block-bindings.php
+++ b/tests/parser/test-block-bindings.php
@@ -54,7 +54,11 @@ class BlockBindingsTest extends RegistryTestCase {
 		$blocks         = $content_parser->parse( $html );
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+
+		// Because this test uses a core block, we use assertArraySubset to avoid brittle
+		// tests when core block attributes change.
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
+		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
 	}
 
 	/* Image block with multiple bindings */
@@ -100,7 +104,11 @@ class BlockBindingsTest extends RegistryTestCase {
 		$blocks         = $content_parser->parse( $html );
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+
+		// Because this test uses a core block, we use assertArraySubset to avoid brittle
+		// tests when core block attributes change.
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
+		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
 	}
 
 	/* Paragraph block binding with default post context */
@@ -137,7 +145,11 @@ class BlockBindingsTest extends RegistryTestCase {
 		$blocks         = $content_parser->parse( $html, $post->ID );
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+
+		// Because this test uses a core block, we use assertArraySubset to avoid brittle
+		// tests when core block attributes change.
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
+		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
 	}
 
 	/* Nested paragraph block binding with context */
@@ -196,7 +208,12 @@ class BlockBindingsTest extends RegistryTestCase {
 		$blocks         = $content_parser->parse( $html );
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+
+		// Because this test uses a core block, we use assertArraySubset to avoid brittle
+		// tests when core block attributes change.
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
+		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
+		$this->assertEquals( 1, count( $blocks['blocks'][0]['innerBlocks'] ), 'Too many inner blocks in result set' );
 	}
 
 	/* Missing block binding */
@@ -222,6 +239,10 @@ class BlockBindingsTest extends RegistryTestCase {
 		$blocks         = $content_parser->parse( $html );
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+
+		// Because this test uses a core block, we use assertArraySubset to avoid brittle
+		// tests when core block attributes change.
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
+		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
 	}
 }

--- a/tests/parser/test-block-bindings.php
+++ b/tests/parser/test-block-bindings.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Class BlockBindingsTest
+ *
+ * @package vip-block-data-api
+ */
+
+namespace WPCOMVIP\BlockDataApi;
+
+use WP_Block;
+
+/**
+ * Test parsing blocks with block binding.
+ */
+class BlockBindingsTest extends RegistryTestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->ensure_core_blocks_are_registered();
+	}
+
+	/* Single paragraph block binding */
+
+	public function test_single_paragraph_block_binding() {
+
+		$this->register_block_bindings_source(
+			'test/block-binding',
+			[
+				'label'              => 'Test paragraph block binding',
+				'get_value_callback' => static function ( array $args, WP_Block $block ) {
+					return sprintf( 'Block binding for %s with arg foo=%s', $block->name, $args['foo'] );
+				},
+			]
+		);
+
+		$html = '
+			<!-- wp:core/paragraph {"metadata":{"bindings":{"content":{"source":"test/block-binding","args":{"foo":"bar"}}}}} -->
+			<p>Fallback content</p>
+			<!-- /wp:core/paragraph -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'core/paragraph',
+				'attributes' => [
+					'content' => 'Block binding for core/paragraph with arg foo=bar',
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
+	}
+}

--- a/tests/parser/test-block-bindings.php
+++ b/tests/parser/test-block-bindings.php
@@ -55,6 +55,52 @@ class BlockBindingsTest extends RegistryTestCase {
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
 	}
 
+	/* Image block with multiple bindings */
+
+	public function test_image_block_with_multiple_bindings() {
+		$this->register_block_bindings_source(
+			'test/block-binding-image-url',
+			[
+				'label'              => 'Test image block binding for URL',
+				'get_value_callback' => static function ( array $args, WP_Block $block ) {
+					return sprintf( 'https://example.com/image.webp?block=%s&foo=%s', $block->name, $args['foo'] );
+				},
+			]
+		);
+
+		$this->register_block_bindings_source(
+			'test/block-binding-image-alt',
+			[
+				'label'              => 'Test image block binding for alt text',
+				'get_value_callback' => static function ( array $args, WP_Block $block ) {
+					return sprintf( 'Block binding for %s with arg foo=%s', $block->name, $args['foo'] );
+				},
+			]
+		);
+
+		$html = '
+			<!-- wp:core/image {"metadata":{"bindings":{"alt":{"source":"test/block-binding-image-alt","args":{"foo":"bar"}},"url":{"source":"test/block-binding-image-url","args":{"foo":"bar"}}}}} -->
+			<img src="https://example.com/fallback.jpg" alt="Fallback alt text" />
+			<!-- /wp:core/image -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'core/image',
+				'attributes' => [
+					'alt' => 'Block binding for core/image with arg foo=bar',
+					'url' => 'https://example.com/image.webp?block=core/image&foo=bar',
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
+	}
+
 	/* Nested paragraph block binding with context */
 
 	public function test_nested_paragraph_block_binding_with_custom_context() {

--- a/tests/parser/test-block-bindings.php
+++ b/tests/parser/test-block-bindings.php
@@ -17,8 +17,8 @@ class BlockBindingsTest extends RegistryTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		if ( version_compare( $GLOBALS['wp_version'], '6.5.0', '<' ) ) {
-			$this->markTestSkipped( 'This test suite requires WordPress 6.5 or higher.' );
+		if ( ! class_exists( 'WP_Block_Bindings_Registry' ) ) {
+			$this->markTestSkipped( 'This test suite requires WP_Block_Bindings_Registry (WordPress 6.5 or higher).' );
 		}
 
 		$this->ensure_core_blocks_are_registered();

--- a/tests/parser/test-block-bindings.php
+++ b/tests/parser/test-block-bindings.php
@@ -63,8 +63,11 @@ class BlockBindingsTest extends RegistryTestCase {
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 
-		// Because this test uses a core block, we use assertArraySubset to avoid brittle
-		// tests when core block attributes change.
+		// Block bindings are currently only supported for specific core blocks.
+		// https://make.wordpress.org/core/2024/03/06/new-feature-the-block-bindings-api/
+		//
+		// Core block attributes can change, so we use assertArraySubset to avoid
+		// brittle assertions.
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
 		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
 	}
@@ -113,8 +116,11 @@ class BlockBindingsTest extends RegistryTestCase {
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 
-		// Because this test uses a core block, we use assertArraySubset to avoid brittle
-		// tests when core block attributes change.
+		// Block bindings are currently only supported for specific core blocks.
+		// https://make.wordpress.org/core/2024/03/06/new-feature-the-block-bindings-api/
+		//
+		// Core block attributes can change, so we use assertArraySubset to avoid
+		// brittle assertions.
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
 		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
 	}
@@ -162,8 +168,11 @@ class BlockBindingsTest extends RegistryTestCase {
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 
-		// Because this test uses a core block, we use assertArraySubset to avoid brittle
-		// tests when core block attributes change.
+		// Block bindings are currently only supported for specific core blocks.
+		// https://make.wordpress.org/core/2024/03/06/new-feature-the-block-bindings-api/
+		//
+		// Core block attributes can change, so we use assertArraySubset to avoid
+		// brittle assertions.
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
 		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
 	}
@@ -233,8 +242,11 @@ class BlockBindingsTest extends RegistryTestCase {
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 
-		// Because this test uses a core block, we use assertArraySubset to avoid brittle
-		// tests when core block attributes change.
+		// Block bindings are currently only supported for specific core blocks.
+		// https://make.wordpress.org/core/2024/03/06/new-feature-the-block-bindings-api/
+		//
+		// Core block attributes can change, so we use assertArraySubset to avoid
+		// brittle assertions.
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
 		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
 		$this->assertEquals( 1, count( $blocks['blocks'][0]['innerBlocks'] ), 'Too many inner blocks in result set' );
@@ -272,8 +284,11 @@ class BlockBindingsTest extends RegistryTestCase {
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 
-		// Because this test uses a core block, we use assertArraySubset to avoid brittle
-		// tests when core block attributes change.
+		// Block bindings are currently only supported for specific core blocks.
+		// https://make.wordpress.org/core/2024/03/06/new-feature-the-block-bindings-api/
+		//
+		// Core block attributes can change, so we use assertArraySubset to avoid
+		// brittle assertions.
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
 		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
 	}

--- a/tests/parser/test-content-parser.php
+++ b/tests/parser/test-content-parser.php
@@ -162,4 +162,57 @@ class ContentParserTest extends RegistryTestCase {
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
 	}
+
+	/* Whitespace block removal */
+
+	public function test_parse_whitespace_block_removal() {
+		$this->register_block_with_attributes( 'test/block', [
+			'content' => [
+				'type'     => 'string',
+				'source'   => 'html',
+				'selector' => 'p',
+			],
+		] );
+
+		$html = join( [
+			// Some intentional whitespace
+			'
+			              ',
+			'<!-- wp:test/block -->
+			<p>Block 1</p>
+			<!-- /wp:test/block -->
+      ',
+			// Some intentional whitespace
+			'
+			              ',
+			'<!-- wp:test/block -->
+			<p>Block 2</p>
+			<!-- /wp:test/block -->
+			',
+			// Some intentional whitespace
+			'
+			              ',
+		] );
+
+		$expected_blocks = [
+			[
+				'name'       => 'test/block',
+				'attributes' => [
+					'content' => 'Block 1',
+				],
+			],
+			[
+				'name'       => 'test/block',
+				'attributes' => [
+					'content' => 'Block 2',
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertEquals( $expected_blocks, $blocks['blocks'], sprintf( 'Blocks do not match: %s', wp_json_encode( $blocks ) ) );
+	}
 }

--- a/tests/parser/test-content-parser.php
+++ b/tests/parser/test-content-parser.php
@@ -47,7 +47,7 @@ class ContentParserTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -98,7 +98,7 @@ class ContentParserTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -157,7 +157,7 @@ class ContentParserTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );

--- a/tests/parser/test-inner-blocks.php
+++ b/tests/parser/test-inner-blocks.php
@@ -88,7 +88,7 @@ class InnerBlocksTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
@@ -181,7 +181,7 @@ class InnerBlocksTest extends RegistryTestCase {
 			],
 		];
 
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );

--- a/tests/parser/test-parser-filters.php
+++ b/tests/parser/test-parser-filters.php
@@ -59,7 +59,7 @@ class ParserFiltersTest extends RegistryTestCase {
 		};
 
 		add_filter( 'vip_block_data_api__allow_block', $block_filter_function, 10, 2 );
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		remove_filter( 'vip_block_data_api__allow_block', $block_filter_function, 10, 2 );
 
@@ -100,7 +100,7 @@ class ParserFiltersTest extends RegistryTestCase {
 		};
 
 		add_filter( 'vip_block_data_api__before_parse_post_content', $replace_post_content_filter );
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );
 		remove_filter( 'vip_block_data_api__before_parse_post_content', $replace_post_content_filter );
 
@@ -143,7 +143,7 @@ class ParserFiltersTest extends RegistryTestCase {
 		};
 
 		add_filter( 'vip_block_data_api__after_parse_blocks', $add_extra_data_filter );
-		$content_parser = new ContentParser( $this->registry );
+		$content_parser = new ContentParser( $this->get_block_registry() );
 		$result         = $content_parser->parse( $html );
 		remove_filter( 'vip_block_data_api__after_parse_blocks', $add_extra_data_filter );
 

--- a/tests/registry-test-case.php
+++ b/tests/registry-test-case.php
@@ -34,11 +34,13 @@ class RegistryTestCase extends WP_UnitTestCase {
 		return WP_Block_Type_Registry::get_instance();
 	}
 
-	protected function register_block_with_attributes( string $block_name, array $attributes ): void {
-		$this->get_block_registry()->register( $block_name, [
+	protected function register_block_with_attributes( string $block_name, array $attributes, array $additional_args = [] ): void {
+		$block_type_args = array_merge( [
 			'apiVersion' => 2,
 			'attributes' => $attributes,
-		] );
+		], $additional_args );
+
+		$this->get_block_registry()->register( $block_name, $block_type_args );
 	}
 
 	protected function register_block_bindings_source( string $source, array $args ): void {

--- a/tests/registry-test-case.php
+++ b/tests/registry-test-case.php
@@ -3,8 +3,10 @@
 namespace WPCOMVIP\BlockDataApi;
 
 use WP_Block_Type_Registry;
+use WP_Block_Bindings_Registry;
 use WP_UnitTestCase;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use function register_core_block_types_from_metadata;
 
 /**
  * Sample test case.
@@ -16,6 +18,11 @@ class RegistryTestCase extends WP_UnitTestCase {
 		$block_registry = WP_Block_Type_Registry::get_instance();
 		foreach ( $block_registry->get_all_registered() as $block ) {
 			$block_registry->unregister( $block->name );
+		}
+
+		$block_bindings_registry = WP_Block_Bindings_Registry::get_instance();
+		foreach ( $block_bindings_registry->get_all_registered() as $source ) {
+			$block_bindings_registry->unregister( $source->name );
 		}
 
 		parent::tearDown();
@@ -32,5 +39,18 @@ class RegistryTestCase extends WP_UnitTestCase {
 			'apiVersion' => 2,
 			'attributes' => $attributes,
 		] );
+	}
+
+	protected function register_block_bindings_source( string $source, array $args ): void {
+		WP_Block_Bindings_Registry::get_instance()->register( $source, $args );
+	}
+
+	/**
+	 * Register core static (not dynamic) blocks.
+	 */
+	protected function ensure_core_blocks_are_registered(): void {
+		if ( empty( WP_Block_Type_Registry::get_instance()->get_all_registered() ) ) {
+			register_core_block_types_from_metadata();
+		}
 	}
 }

--- a/tests/registry-test-case.php
+++ b/tests/registry-test-case.php
@@ -12,18 +12,10 @@ use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 class RegistryTestCase extends WP_UnitTestCase {
 	use ArraySubsetAsserts;
 
-	protected $registry;
-	protected $globally_registered_blocks = [];
-
-	protected function setUp(): void {
-		parent::setUp();
-
-		$this->registry = new WP_Block_Type_Registry();
-	}
-
 	protected function tearDown(): void {
-		foreach ( $this->globally_registered_blocks as $block_name ) {
-			$this->unregister_global_block( $block_name );
+		$block_registry = WP_Block_Type_Registry::get_instance();
+		foreach ( $block_registry->get_all_registered() as $block ) {
+			$block_registry->unregister( $block->name );
 		}
 
 		parent::tearDown();
@@ -31,31 +23,14 @@ class RegistryTestCase extends WP_UnitTestCase {
 
 	/* Helper methods */
 
-	protected function register_block_with_attributes( $block_name, $attributes ) {
-		$this->registry->register( $block_name, [
+	protected function get_block_registry(): WP_Block_Type_Registry {
+		return WP_Block_Type_Registry::get_instance();
+	}
+
+	protected function register_block_with_attributes( string $block_name, array $attributes ): void {
+		$this->get_block_registry()->register( $block_name, [
 			'apiVersion' => 2,
 			'attributes' => $attributes,
 		] );
-	}
-
-	/* Global registrations */
-
-	protected function register_global_block_with_attributes( $block_name, $attributes ) {
-		// Use this function for mocking blocks definitions that need to persist across HTTP requests, like GraphQL tests.
-
-		WP_Block_Type_Registry::get_instance()->register( $block_name, [
-			'apiVersion' => 2,
-			'attributes' => $attributes,
-		] );
-
-		$this->globally_registered_blocks[] = $block_name;
-	}
-
-	protected function unregister_global_block( $block_name ) {
-		$registry = WP_Block_Type_Registry::get_instance();
-
-		if ( $registry->is_registered( $block_name ) ) {
-			$registry->unregister( $block_name );
-		}
 	}
 }

--- a/tests/registry-test-case.php
+++ b/tests/registry-test-case.php
@@ -20,9 +20,11 @@ class RegistryTestCase extends WP_UnitTestCase {
 			$block_registry->unregister( $block->name );
 		}
 
-		$block_bindings_registry = WP_Block_Bindings_Registry::get_instance();
-		foreach ( $block_bindings_registry->get_all_registered() as $source ) {
-			$block_bindings_registry->unregister( $source->name );
+		if ( class_exists( 'WP_Block_Bindings_Registry' ) ) {
+			$block_bindings_registry = WP_Block_Bindings_Registry::get_instance();
+			foreach ( $block_bindings_registry->get_all_registered() as $source ) {
+				$block_bindings_registry->unregister( $source->name );
+			}
 		}
 
 		parent::tearDown();

--- a/tests/registry-test-case.php
+++ b/tests/registry-test-case.php
@@ -6,7 +6,6 @@ use WP_Block_Type_Registry;
 use WP_Block_Bindings_Registry;
 use WP_UnitTestCase;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
-use function register_core_block_types_from_metadata;
 
 /**
  * Sample test case.
@@ -15,14 +14,24 @@ class RegistryTestCase extends WP_UnitTestCase {
 	use ArraySubsetAsserts;
 
 	protected function tearDown(): void {
+		// Unregister non-core blocks.
 		$block_registry = WP_Block_Type_Registry::get_instance();
-		foreach ( $block_registry->get_all_registered() as $block ) {
-			$block_registry->unregister( $block->name );
+		foreach ( $block_registry->get_all_registered() as $block_type ) {
+			if ( 'core/' === substr( $block_type->name, 0, 5 ) ) {
+				continue;
+			}
+
+			$block_registry->unregister( $block_type->name );
 		}
 
 		if ( class_exists( 'WP_Block_Bindings_Registry' ) ) {
+			// Unregister non-core block bindings.
 			$block_bindings_registry = WP_Block_Bindings_Registry::get_instance();
 			foreach ( $block_bindings_registry->get_all_registered() as $source ) {
+				if ( 'core/' === substr( $source->name, 0, 5 ) ) {
+					continue;
+				}
+
 				$block_bindings_registry->unregister( $source->name );
 			}
 		}
@@ -47,14 +56,5 @@ class RegistryTestCase extends WP_UnitTestCase {
 
 	protected function register_block_bindings_source( string $source, array $args ): void {
 		WP_Block_Bindings_Registry::get_instance()->register( $source, $args );
-	}
-
-	/**
-	 * Register core static (not dynamic) blocks.
-	 */
-	protected function ensure_core_blocks_are_registered(): void {
-		if ( empty( WP_Block_Type_Registry::get_instance()->get_all_registered() ) ) {
-			register_core_block_types_from_metadata();
-		}
 	}
 }

--- a/tests/rest/test-rest-api.php
+++ b/tests/rest/test-rest-api.php
@@ -8,17 +8,14 @@
 namespace WPCOMVIP\BlockDataApi;
 
 use Exception;
-use WP_Block_Type_Registry;
-use WP_UnitTestCase;
 use WP_REST_Server;
 use WP_REST_Request;
 
 /**
  * e2e tests to ensure that the REST API endpoint is available.
  */
-class RestApiTest extends WP_UnitTestCase {
+class RestApiTest extends RegistryTestCase {
 	private $server;
-	private $globally_registered_blocks = [];
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -34,15 +31,11 @@ class RestApiTest extends WP_UnitTestCase {
 		global $wp_rest_server;
 		$wp_rest_server = null;
 
-		foreach ( $this->globally_registered_blocks as $block_name ) {
-			$this->unregister_global_block( $block_name );
-		}
-
 		parent::tearDown();
 	}
 
 	public function test_rest_api_returns_blocks_for_post() {
-		$this->register_global_block_with_attributes( 'test/custom-heading', [
+		$this->register_block_with_attributes( 'test/custom-heading', [
 			'content' => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -55,7 +48,7 @@ class RestApiTest extends WP_UnitTestCase {
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-quote', [
+		$this->register_block_with_attributes( 'test/custom-quote', [
 			'value'    => [
 				'type'               => 'string',
 				'source'             => 'html',
@@ -72,7 +65,7 @@ class RestApiTest extends WP_UnitTestCase {
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-paragraph', [
+		$this->register_block_with_attributes( 'test/custom-paragraph', [
 			'content'     => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -88,14 +81,14 @@ class RestApiTest extends WP_UnitTestCase {
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-separator', [
+		$this->register_block_with_attributes( 'test/custom-separator', [
 			'opacity' => [
 				'type'    => 'string',
 				'default' => 'alpha-channel',
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-media-text', [
+		$this->register_block_with_attributes( 'test/custom-media-text', [
 			'align'             => [
 				'type'    => 'string',
 				'default' => 'none',
@@ -245,7 +238,7 @@ class RestApiTest extends WP_UnitTestCase {
 	}
 
 	public function test_rest_api_does_not_return_excluded_blocks_for_post() {
-		$this->register_global_block_with_attributes( 'test/custom-heading', [
+		$this->register_block_with_attributes( 'test/custom-heading', [
 			'content' => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -258,7 +251,7 @@ class RestApiTest extends WP_UnitTestCase {
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-quote', [
+		$this->register_block_with_attributes( 'test/custom-quote', [
 			'value'    => [
 				'type'               => 'string',
 				'source'             => 'html',
@@ -275,7 +268,7 @@ class RestApiTest extends WP_UnitTestCase {
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-paragraph', [
+		$this->register_block_with_attributes( 'test/custom-paragraph', [
 			'content'     => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -291,14 +284,14 @@ class RestApiTest extends WP_UnitTestCase {
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-separator', [
+		$this->register_block_with_attributes( 'test/custom-separator', [
 			'opacity' => [
 				'type'    => 'string',
 				'default' => 'alpha-channel',
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-media-text', [
+		$this->register_block_with_attributes( 'test/custom-media-text', [
 			'align'             => [
 				'type'    => 'string',
 				'default' => 'none',
@@ -426,7 +419,7 @@ class RestApiTest extends WP_UnitTestCase {
 	}
 
 	public function test_rest_api_only_returns_included_blocks_for_post() {
-		$this->register_global_block_with_attributes( 'test/custom-heading', [
+		$this->register_block_with_attributes( 'test/custom-heading', [
 			'content' => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -439,7 +432,7 @@ class RestApiTest extends WP_UnitTestCase {
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-quote', [
+		$this->register_block_with_attributes( 'test/custom-quote', [
 			'value'    => [
 				'type'               => 'string',
 				'source'             => 'html',
@@ -456,7 +449,7 @@ class RestApiTest extends WP_UnitTestCase {
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-paragraph', [
+		$this->register_block_with_attributes( 'test/custom-paragraph', [
 			'content'     => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -472,14 +465,14 @@ class RestApiTest extends WP_UnitTestCase {
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-separator', [
+		$this->register_block_with_attributes( 'test/custom-separator', [
 			'opacity' => [
 				'type'    => 'string',
 				'default' => 'alpha-channel',
 			],
 		] );
 
-		$this->register_global_block_with_attributes( 'test/custom-media-text', [
+		$this->register_block_with_attributes( 'test/custom-media-text', [
 			'align'             => [
 				'type'    => 'string',
 				'default' => 'none',
@@ -590,7 +583,7 @@ class RestApiTest extends WP_UnitTestCase {
 			'show_in_rest' => true,
 		]);
 
-		$this->register_global_block_with_attributes( 'test/custom-paragraph', [
+		$this->register_block_with_attributes( 'test/custom-paragraph', [
 			'content' => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -645,7 +638,7 @@ class RestApiTest extends WP_UnitTestCase {
 			'public' => false,
 		]);
 
-		$this->register_global_block_with_attributes( 'test/custom-paragraph', [
+		$this->register_block_with_attributes( 'test/custom-paragraph', [
 			'content' => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -681,7 +674,7 @@ class RestApiTest extends WP_UnitTestCase {
 			'show_in_rest' => false,
 		]);
 
-		$this->register_global_block_with_attributes( 'test/custom-paragraph', [
+		$this->register_block_with_attributes( 'test/custom-paragraph', [
 			'content' => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -712,7 +705,7 @@ class RestApiTest extends WP_UnitTestCase {
 	}
 
 	public function test_rest_api_returns_error_for_unpublished_post() {
-		$this->register_global_block_with_attributes( 'test/custom-paragraph', [
+		$this->register_block_with_attributes( 'test/custom-paragraph', [
 			'content' => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -763,7 +756,7 @@ class RestApiTest extends WP_UnitTestCase {
 	}
 
 	public function test_rest_api_returns_error_for_include_and_exclude_filter() {
-		$this->register_global_block_with_attributes( 'test/custom-paragraph', [
+		$this->register_block_with_attributes( 'test/custom-paragraph', [
 			'content' => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -798,7 +791,7 @@ class RestApiTest extends WP_UnitTestCase {
 	}
 
 	public function test_rest_api_returns_error_for_unexpected_exception() {
-		$this->register_global_block_with_attributes( 'test/custom-paragraph', [
+		$this->register_block_with_attributes( 'test/custom-paragraph', [
 			'content' => [
 				'type'               => 'rich-text',
 				'source'             => 'rich-text',
@@ -856,22 +849,5 @@ class RestApiTest extends WP_UnitTestCase {
 			},
 			E_USER_WARNING
 		);
-	}
-
-	private function register_global_block_with_attributes( $block_name, $attributes ) {
-		WP_Block_Type_Registry::get_instance()->register( $block_name, [
-			'apiVersion' => 2,
-			'attributes' => $attributes,
-		] );
-
-		$this->globally_registered_blocks[] = $block_name;
-	}
-
-	private function unregister_global_block( $block_name ) {
-		$registry = WP_Block_Type_Registry::get_instance();
-
-		if ( $registry->is_registered( $block_name ) ) {
-			$registry->unregister( $block_name );
-		}
 	}
 }


### PR DESCRIPTION
## Description

This PR adds support for [block bindings](https://make.wordpress.org/core/2024/03/06/new-feature-the-block-bindings-api/), introduced in WordPress 6.5.

The changes here are relatively small, although they are accompanied by some test improvements and cleanup, so the diff is a bit larger than it otherwise would be. Breakdown of commits:

### New functionality

- [Update parser to leverage core block rendering](https://github.com/Automattic/vip-block-data-api/commit/1b6984208eeab86414141c14bf8555d6b70ddd9e): This is the most impactful commit:
  - In order to support block binding without copying many lines of code from core, we create a block instance and render it (including all of its inner blocks), then access the computed attributes and inner HTML. This lets Core do the heavy lifting.
  - Then, we walk the tree and apply our logic to extract sourced attributes.

### Test improvements

No test data was changed in this PR (only ordering).

- [Simplify and improve RegistryTestCase](https://github.com/Automattic/vip-block-data-api/commit/40ff45772a19f85007ab8138265b36829cdd09f2): Removes the unnecessary distinction between "global" and normal block type registration and delegates more work to Core classes.
- [Update tests to match alphabetical key order](https://github.com/Automattic/vip-block-data-api/commit/ccbc687f353b762d9cd91c16b9d7e3e239a63889). Sorting the array keys of attributes more less brittle tests. 

### Additional test cases

- [Add failing test for single block binding](https://github.com/Automattic/vip-block-data-api/commit/b974c6dd807b97ee1d3635bd1041297114d36022).
- [Add (now passing) test for block binding with context](https://github.com/Automattic/vip-block-data-api/commit/f880209e70fa47c6275fe5ef4ac57eb3f50fdbb7)
No test data was changed, only order.
- [Add additional test cases](https://github.com/Automattic/vip-block-data-api/commit/12f50d9f724b6c3e276fcbf1dae0d3ef145bba06)
- [Add test for block binding with post context](https://github.com/Automattic/vip-block-data-api/commit/510ca2ef9f12c339e33d1f4c6cb18cacc317247c)
- [Skip block binding tests when WordPress < 6.5](https://github.com/Automattic/vip-block-data-api/pull/74/commits/bfec40a68c12f4922c501d7ed5948a7ca8af3f2d)