### PR TITLE
Add synced patterns support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1299,6 +1299,38 @@ Note that this filter is evaluated after the [`include`](#include) and [`exclude
 
 ---
 
+### `vip_block_data_api__sourced_block_inner_blocks`
+
+Modify a block's inner blocks before they are recursively added the result tree.
+
+```php
+/**
+ * Filters a block's inner blocks before recursive iteration.
+ *
+ * @param array  $inner_blocks An array of inner block (WP_Block) instances.
+ * @param string $block_name   Name of the parsed block, e.g. 'core/paragraph'.
+ * @param int    $post_id      Post ID associated with the parsed block.
+ * @param array  $block        Result of parse_blocks() for this block.
+ */
+$inner_blocks = apply_filters( 'vip_block_data_api__sourced_block_inner_blocks', $inner_blocks, $block_name, $this->post_id, $block->parsed_block );
+```
+
+This is useful if you want to add or remove inner blocks from the tree based on the parent block. Note that the inner blocks are WP_Block instances, not the associative arrays returned by `parse_blocks`.
+
+```php
+add_filter( 'vip_block_data_api__sourced_block_inner_blocks', 'remove_gallery_inner_blocks', 10, 4 );
+
+function remove_gallery_inner_blocks( $inner_blocks, $block_name, $post_id, $block ) {
+    if ( 'core/gallery' !== $block_name ) {
+        return $inner_blocks;
+    }
+
+    return [];
+}
+```
+
+---
+
 ### `vip_block_data_api__sourced_block_result`
 
 Modify or add attributes to a block's output in the Block Data API.

--- a/README.md
+++ b/README.md
@@ -1321,11 +1321,11 @@ This is useful if you want to add or remove inner blocks from the tree based on 
 add_filter( 'vip_block_data_api__sourced_block_inner_blocks', 'remove_gallery_inner_blocks', 10, 4 );
 
 function remove_gallery_inner_blocks( $inner_blocks, $block_name, $post_id, $block ) {
-    if ( 'core/gallery' !== $block_name ) {
-        return $inner_blocks;
+    if ( 'core/gallery' === $block_name ) {
+        return [];
     }
 
-    return [];
+    return $inner_blocks;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1341,11 +1341,11 @@ Modify or add attributes to a block's output in the Block Data API.
  *
  * @param array  $sourced_block An associative array of parsed block data with keys 'name' and 'attributes'.
  * @param string $block_name    The name of the parsed block, e.g. 'core/paragraph'.
- * @param string $post_id       The post ID associated with the parsed block.
- * @param string $block         The result of parse_blocks() for this block.
+ * @param int    $post_id       The post ID associated with the parsed block.
+ * @param array  $block         The result of parse_blocks() for this block.
  *                              Contains 'blockName', 'attrs', 'innerHTML', and 'innerBlocks' keys.
  */
-$sourced_block = apply_filters( 'vip_block_data_api__sourced_block_result', $sourced_block, $block_name, $post_id, $block);
+$sourced_block = apply_filters( 'vip_block_data_api__sourced_block_result', $sourced_block, $block_name, $post_id, $block->parsed_block);
 ```
 
 This is useful when block rendering requires attributes stored in post metadata or outside of a block's markup. This filter can be used to add attributes to any core or custom block. For example:
@@ -1440,7 +1440,7 @@ $result = apply_filters( 'vip_block_data_api__after_parse_blocks', $result, $pos
 This filter is called directly before returning a result in the REST API. Use this filter to add additional metadata or debug information to the API output.
 
 ```php
-add_action( 'vip_block_data_api__after_parse_blocks', 'add_block_data_debug_info', 10, 2 );
+add_filter( 'vip_block_data_api__after_parse_blocks', 'add_block_data_debug_info', 10, 2 );
 
 function add_block_data_debug_info( $result, $post_id ) {
 	$result['debug']['my-value'] = 123;

--- a/README.md
+++ b/README.md
@@ -1301,7 +1301,7 @@ Note that this filter is evaluated after the [`include`](#include) and [`exclude
 
 ### `vip_block_data_api__sourced_block_inner_blocks`
 
-Modify a block's inner blocks before they are recursively added the result tree.
+Modify a block's inner blocks before they are recursively added to the result tree.
 
 ```php
 /**

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This plugin is currently developed for use on WordPress sites hosted on the VIP 
   - [Example Post](#example-post)
   - [`include`](#include)
   - [`exclude`](#exclude)
-- [Code Filters](#code-filters)
+- [Filters and actions](#filters-and-actions)
   - [GraphQL](#graphql-1)
   - [REST](#rest-1)
   - [`vip_block_data_api__rest_validate_post_id`](#vip_block_data_api__rest_validate_post_id)
@@ -1177,7 +1177,7 @@ This query parameter cannot be used at the same time as [the `include` query par
 
 Note that custom block filter rules can also be created in code via [the `vip_block_data_api__allow_block` filter](#vip_block_data_api__allow_block).
 
-## Code Filters
+## Filters and actions
 
 ### GraphQL
 
@@ -1190,7 +1190,7 @@ add_filter( 'vip_block_data_api__is_graphql_enabled', '__return_false', 10, 1 );
 
 ### REST
 
-These filters can be applied to limit access to the REST API and modify the output of parsed blocks.
+These filters and actions can be applied to limit access to the REST API and modify the output of parsed blocks.
 
 ### `vip_block_data_api__rest_validate_post_id`
 
@@ -1427,6 +1427,33 @@ This would add `debug.my-value` to all Block Data API REST results:
     "my-value": 123
   },
   "blocks": [ /* ... */ ]
+}
+```
+
+---
+
+### `vip_block_data_api__before_block_render`
+### `vip_block_data_api__after_block_render`
+
+Perform actions before or after blocks are rendered by the `ContentParser`, such as hooking into core block rendering functions.
+
+```php
+add_action( 'vip_block_data_api__before_block_render', 'add_block_context_filter', 10, 2 );
+add_action( 'vip_block_data_api__after_block_render', 'remove_block_context_filter', 10, 2 );
+
+function block_context_filter( $block_context, $parsed_block ) {
+    // Modify block context before rendering
+    $block_context['custom/injected-context'] = 'example';
+
+    return $block_context;
+}
+
+function add_block_context_filter( $blocks, $post_id ) {
+    add_filter( 'render_block_context', 'block_context_filter', 10, 2 );
+}
+
+function remove_block_context_filter( $blocks, $post_id ) {
+    remove_filter( 'render_block_context', 'block_context_filter', 10 );
 }
 ```
 

--- a/src/parser/block-additions/core-block.php
+++ b/src/parser/block-additions/core-block.php
@@ -152,8 +152,8 @@ class CoreBlock {
 	 * duplication when they are used multiple times within the same tree.
 	 *
 	 * Using a hash of attributes is important because they may contain synced
-	 * synced pattern overrides, which can change the inner block content. The
-	 * attributes contain the synced pattern post ID, so uniqueness is built-in.
+	 * pattern overrides, which can change the inner block content. The attributes
+	 * contain the synced pattern post ID, so uniqueness is built-in.
 	 *
 	 * @param array $parsed_block Parsed block data.
 	 * @return string
@@ -191,7 +191,7 @@ class CoreBlock {
 
 	/**
 	 * Remove the empty array that gets assigned to the content attribute due to
-	 * this likely bug in the code that implements synced pattern overrides:
+	 * this bug / side effect in the code that implements synced pattern overrides:
 	 *
 	 * phpcs:disable Generic.Commenting.DocComment.LongNotCapital
 	 * https://github.com/WordPress/WordPress/blob/6.6.1/wp-includes/blocks/block.php#L73

--- a/src/parser/block-additions/core-block.php
+++ b/src/parser/block-additions/core-block.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Enhancements for the core/block block, also known as synced patterns (formerly reusable blocks).
+ *
+ * @package vip-block-data-api
+ */
+
+namespace WPCOMVIP\BlockDataApi\ContentParser\BlockAdditions;
+
+defined( 'ABSPATH' ) || die();
+
+use WP_Block;
+use WP_Block_Supports;
+use function add_action;
+use function add_filter;
+use function remove_filter;
+
+/**
+ * Enhance core/block block by capturing its inner blocks.
+ */
+class CoreBlock {
+	/**
+	 * The block name for synced patterns.
+	 *
+	 * @var string
+	 */
+	private static $block_name = 'core/block';
+
+	/**
+	 * A store of captured inner blocks. See `capture_inner_blocks`.
+	 *
+	 * @var array
+	 *
+	 * @access private
+	 */
+	protected static $captured_inner_blocks = [];
+
+	/**
+	 * Initialize the CoreBlock class.
+	 *
+	 * @access private
+	 */
+	public static function init(): void {
+		add_action( 'vip_block_data_api__before_block_render', [ __CLASS__, 'setup_before_render' ], 10, 0 );
+		add_action( 'vip_block_data_api__after_block_render', [ __CLASS__, 'cleanup_after_render' ], 10, 0 );
+		add_filter( 'vip_block_data_api__sourced_block_inner_blocks', [ __CLASS__, 'get_inner_blocks' ], 5, 4 );
+	}
+
+	/**
+	 * Setup before render.
+	 */
+	public static function setup_before_render(): void {
+		/**
+		 * Hook into the `render_block` filter, which is near the end of WP_Block#render().
+		 * This allows us to capture the inner blocks of synced patterns ("core/block").
+		 * See `capture_inner_blocks`.
+		 */
+		add_filter( 'render_block', [ __CLASS__, 'capture_inner_blocks' ], 10, 3 );
+	}
+
+	/**
+	 * Cleanup after render.
+	 */
+	public static function cleanup_after_render() {
+		self::$captured_inner_blocks = [];
+		remove_filter( 'render_block', [ __CLASS__, 'capture_inner_blocks' ], 10 );
+	}
+
+	/**
+	 * Capture the inner blocks of synced patterns during block rendering. Intended
+	 * for use with the `render_block` filter.
+	 *
+	 * We have no intention of filtering the rendered block content, but this hook
+	 * is conveniently located near the end of WP_Block#render() after block
+	 * processing is finished. We get access to the parent block via the global
+	 * static class `WP_Block_Supports`.
+	 *
+	 * This approach is necessary because synced patterns (core/block) are dynamic
+	 * blocks, and core's method of rendering dynamic blocks severs the connection
+	 * between the parent block and its inner blocks:
+	 *
+	 * https://github.com/WordPress/WordPress/blob/6.6.1/wp-includes/class-wp-block.php#L519
+	 *
+	 * A dynamic block's render callback function returns only an HTML string.
+	 * This is suitable for most dynamic blocks, but synced patterns are just
+	 * references to other blocks, so it can be frustrating to see their contents
+	 * missing from the Block Data API. Capturing synced pattern content as inner
+	 * blocks is extremely useful and avoids the need for additional API calls.
+	 *
+	 * @param string   $block_content Rendered block content.
+	 * @param array    $_parsed_block Parsed block data (unused).
+	 * @param WP_Block $block         Block instance.
+	 * @return string
+	 */
+	public static function capture_inner_blocks( string $block_content, array $_parsed_block, WP_Block $block ): string {
+		// Get the parent block that is currently being rendered. This is fragile,
+		// but is currently the only way we can get access to the parent block from
+		// inside a dynamic block's render callback function.
+		//
+		// https://github.com/WordPress/WordPress/blob/6.6.1/wp-includes/class-wp-block.php#L517
+		$parent_block = WP_Block_Supports::$block_to_render;
+
+		// If the parent block is not a synced pattern, do nothing.
+		if ( ! isset( $parent_block['attrs']['ref'] ) || self::$block_name !== $parent_block['blockName'] ) {
+			return $block_content;
+		}
+
+		// Capture the inner block for this synced pattern.
+		self::capture_inner_block( $parent_block['attrs']['ref'], $block );
+
+		return $block_content;
+	}
+
+	/**
+	 * Get captured inner blocks for synced patterns. Intended for use with
+	 * the `vip_block_data_api__sourced_block_inner_blocks` filter.
+	 *
+	 * @param array    $inner_blocks Inner blocks.
+	 * @param string   $block_name   Block name.
+	 * @param int|null $_post_id     Post ID (unused).
+	 * @param array    $parsed_block Parsed block data.
+	 * @return array
+	 */
+	public static function get_inner_blocks( array $inner_blocks, string $block_name, int|null $_post_id, array $parsed_block ): array {
+		if ( self::$block_name !== $block_name || ! isset( $parsed_block['attrs']['ref'] ) ) {
+			return $inner_blocks;
+		}
+
+		$synced_pattern_id = $parsed_block['attrs']['ref'];
+
+		if ( ! isset( self::$captured_inner_blocks[ $synced_pattern_id ] ) ) {
+			return $inner_blocks;
+		}
+
+		return self::$captured_inner_blocks[ $synced_pattern_id ];
+	}
+
+	/**
+	 * Capture inner block for a synced pattern.
+	 *
+	 * @param int      $synced_pattern_id Synced pattern ID.
+	 * @param WP_Block $block             Inner block.
+	 */
+	protected static function capture_inner_block( int $synced_pattern_id, WP_Block $block ): void {
+		if ( ! isset( self::$captured_inner_blocks[ $synced_pattern_id ] ) ) {
+			self::$captured_inner_blocks[ $synced_pattern_id ] = [];
+		}
+
+		self::$captured_inner_blocks[ $synced_pattern_id ][] = $block;
+	}
+}
+
+CoreBlock::init();

--- a/src/parser/block-additions/core-block.php
+++ b/src/parser/block-additions/core-block.php
@@ -109,7 +109,7 @@ class CoreBlock {
 		// inside a dynamic block's render callback function.
 		//
 		// https://github.com/WordPress/WordPress/blob/6.6.1/wp-includes/class-wp-block.php#L517
-		$parent_block = WP_Block_Supports::$block_to_render;
+		$parent_block = isset( WP_Block_Supports::$block_to_render ) ? WP_Block_Supports::$block_to_render : [];
 
 		// If the parent block is not a synced pattern, do nothing.
 		if ( ! isset( $parent_block['attrs']['ref'] ) || self::$block_name !== $parent_block['blockName'] ) {

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -236,7 +236,8 @@ class ContentParser {
 	 *
 	 * This loosely mirrors the code in the `render_block` function in core, but
 	 * allows us to capture the block instance so that we can traverse the tree:
-	 * https://github.com/WordPress/WordPress/blob/01d2199622d52b08d1704871770c68e35d2a80dc/wp-includes/blocks.php#L2012
+	 *
+	 * https://github.com/WordPress/WordPress/blob/6.6.1/wp-includes/blocks.php#L1959
 	 *
 	 * @param array $parsed_block Parsed block (result of `parse_blocks`).
 	 * @return WP_Block

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -340,12 +340,8 @@ class ContentParser {
 			$attribute_source        = $block_attribute_definition['source'] ?? null;
 			$attribute_default_value = $block_attribute_definition['default'] ?? null;
 
-			// If the attribute was resolved from a block binding, it has a value, and it's not the default value, skip.
-			if (
-				isset( $block_attributes['metadata']['bindings'][ $block_attribute_name ], $block_attributes[ $block_attribute_name ] ) &&
-				! empty( $block_attributes[ $block_attribute_name ] ) &&
-				$block_attributes[ $block_attribute_name ] !== $attribute_default_value
-			) {
+			// If the attribute was resolved from a block binding, skip.
+			if ( $this->has_successful_block_binding( $block_attribute_name, $block_attributes, $attribute_default_value ) ) {
 				continue;
 			}
 
@@ -382,6 +378,31 @@ class ContentParser {
 		ksort( $block_attributes );
 
 		return $block_attributes;
+	}
+
+	/**
+	 * Inspect the attribute to determine if it was resolved from a block binding.
+	 *
+	 * @param string $attribute_name Attribute name.
+	 * @param array  $attributes     Block attributes.
+	 * @param mixed  $default_value  Default value of the attribute.
+	 */
+	protected function has_successful_block_binding( string $attribute_name, array $attributes, mixed $default_value ): bool {
+		// No bindings defined.
+		if ( ! isset( $attributes['metadata']['bindings'] ) ) {
+			return false;
+		}
+
+		$attribute_value = $attributes[ $attribute_name ] ?? null;
+		$bindings        = $attributes['metadata']['bindings'];
+
+		// If the attribute is empty or matches the default value, it was not resolved
+		// from a block binding.
+		if ( empty( $attribute_value ) || $attribute_value === $default_value ) {
+			return false;
+		}
+
+		return isset( $bindings[ $attribute_name ]['source'] ) || isset( $bindings['__default']['source'] );
 	}
 
 	/**

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -15,6 +15,7 @@ use WP_Block;
 use WP_Block_Type_Registry;
 use Symfony\Component\DomCrawler\Crawler;
 use function apply_filters;
+use function do_action;
 use function parse_blocks;
 
 /**
@@ -147,6 +148,16 @@ class ContentParser {
 
 			$blocks = parse_blocks( $post_content );
 
+			/**
+			 * Fires before blocks are rendered, allowing code to hook into the block rendering process.
+			 *
+			 * @param array    $blocks  Blocks being rendered.
+			 * @param int|null $post_id Post ID associated with the blocks.
+			 *
+			 * @since 1.4.0
+			 */
+			do_action( 'vip_block_data_api__before_block_render', $blocks, $post_id );
+
 			$sourced_blocks = array_map( function ( $block ) use ( $filter_options ) {
 				// Render the block, then walk the tree using source_block to apply our
 				// sourced attribute logic.
@@ -156,6 +167,16 @@ class ContentParser {
 			}, $blocks );
 
 			$sourced_blocks = array_values( array_filter( $sourced_blocks ) );
+
+			/**
+			 * Fires after block are rendered, allowing code to hook into the block rendering process.
+			 *
+			 * @param array    $sourced_blocks Raw render result.
+			 * @param int|null $post_id        Post ID associated with the blocks.
+			 *
+			 * @since 1.4.0
+			 */
+			do_action( 'vip_block_data_api__after_block_render', $sourced_blocks, $post_id );
 
 			$result = [
 				'blocks' => $sourced_blocks,

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -85,7 +85,7 @@ class ContentParser {
 		if ( $is_whitespace_block ) {
 			return false;
 		}
-		
+
 		if ( ! empty( $filter_options['include'] ) ) {
 			$is_block_included = in_array( $block_name, $filter_options['include'] );
 		} elseif ( ! empty( $filter_options['exclude'] ) ) {
@@ -284,6 +284,16 @@ class ContentParser {
 
 		// WP_Block#inner_blocks can be an array or WP_Block_List (iterable).
 		$inner_blocks = iterator_to_array( $block->inner_blocks );
+
+		/**
+		 * Filters a block's inner blocks before recursive iteration.
+		 *
+		 * @param array  $inner_blocks An array of inner block (WP_Block) instances.
+		 * @param string $block_name   Name of the parsed block, e.g. 'core/paragraph'.
+		 * @param int    $post_id      Post ID associated with the parsed block.
+		 * @param array  $block        Result of parse_blocks() for this block.
+		 */
+		$inner_blocks = apply_filters( 'vip_block_data_api__sourced_block_inner_blocks', $inner_blocks, $block_name, $this->post_id, $block->parsed_block );
 
 		// Recursively iterate over inner blocks.
 		$sourced_inner_blocks = array_values( array_filter( array_map( function ( $inner_block ) use ( $filter_options ) {

--- a/tests/parser/test-synced-patterns.php
+++ b/tests/parser/test-synced-patterns.php
@@ -216,8 +216,11 @@ class SyncedPatternsTest extends RegistryTestCase {
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 
-		// Because this test uses core blocks, we use assertArraySubset to avoid brittle
-		// tests when core block attributes change.
+		// Block bindings are currently only supported for specific core blocks.
+		// https://make.wordpress.org/core/2024/03/06/new-feature-the-block-bindings-api/
+		//
+		// Core block attributes can change, so we use assertArraySubset to avoid
+		// brittle assertions.
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
 		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
 		$this->assertEquals( 1, count( $blocks['blocks'][0]['innerBlocks'] ), 'Too many inner blocks in synced pattern' );
@@ -506,8 +509,11 @@ class SyncedPatternsTest extends RegistryTestCase {
 
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 
-		// Because this test uses core blocks, we use assertArraySubset to avoid brittle
-		// tests when core block attributes change.
+		// Block bindings are currently only supported for specific core blocks.
+		// https://make.wordpress.org/core/2024/03/06/new-feature-the-block-bindings-api/
+		//
+		// Core block attributes can change, so we use assertArraySubset to avoid
+		// brittle assertions.
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
 		$this->assertEquals( 3, count( $blocks['blocks'] ), 'Too many blocks in result set' );
 

--- a/tests/parser/test-synced-patterns.php
+++ b/tests/parser/test-synced-patterns.php
@@ -1,0 +1,527 @@
+<?php
+/**
+ * Class SyncedPatternsTest
+ *
+ * @package vip-block-data-api
+ */
+
+namespace WPCOMVIP\BlockDataApi;
+
+use WP_Block;
+
+/**
+ * Test parsing blocks with synced patterns.
+ */
+class SyncedPatternsTest extends RegistryTestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		if ( ! function_exists( 'resolve_pattern_blocks' ) ) {
+			$this->markTestSkipped( 'This test suite requires resolve_pattern_blocks (WordPress 6.6 or higher).' );
+		}
+	}
+
+	/* Simple synced pattern */
+
+	public function test_simple_synced_pattern() {
+		$this->register_block_with_attributes( 'test/custom-block', [
+			'content' => [
+				'type'               => 'rich-text',
+				'source'             => 'rich-text',
+				'selector'           => 'p',
+				'__experimentalRole' => 'content',
+			],
+			'bing'    => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'p',
+				'attribute' => 'data-bing',
+			],
+		] );
+
+		$synced_pattern_content = '
+			<!-- wp:test/custom-block -->
+			<p data-bing="bong">My synced pattern content</p>
+			<!-- /wp:test/custom-block -->
+		';
+
+		$synced_pattern = $this->factory()->post->create_and_get( [
+			'post_content' => $synced_pattern_content,
+			'post_status'  => 'publish',
+			'post_type'    => 'wp_block',
+		] );
+
+		$html = sprintf( '<!-- wp:block {"ref":%d} /-->', $synced_pattern->ID );
+
+		$expected_blocks = [
+			[
+				'name'        => 'core/block',
+				'attributes'  => [
+					'ref' => $synced_pattern->ID,
+				],
+				'innerBlocks' => [
+					[
+						'name'       => 'test/custom-block',
+						'attributes' => [
+							'content' => 'My synced pattern content',
+							'bing'    => 'bong',
+						],
+					],
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertEquals( $expected_blocks, $blocks['blocks'], sprintf( 'Blocks not equal: %s', wp_json_encode( $blocks['blocks'] ) ) );
+	}
+
+	/* Multiple synced patterns */
+
+	public function test_multiple_synced_patterns() {
+		$this->register_block_with_attributes( 'test/custom-block', [
+			'content' => [
+				'type'               => 'rich-text',
+				'source'             => 'rich-text',
+				'selector'           => 'p',
+				'__experimentalRole' => 'content',
+			],
+			'bing'    => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'p',
+				'attribute' => 'data-bing',
+			],
+		] );
+
+		$synced_pattern_content_1 = '
+			<!-- wp:test/custom-block -->
+			<p data-bing="bong">My first synced pattern content</p>
+			<!-- /wp:test/custom-block -->
+		';
+
+		$synced_pattern_1 = $this->factory()->post->create_and_get( [
+			'post_content' => $synced_pattern_content_1,
+			'post_status'  => 'publish',
+			'post_type'    => 'wp_block',
+		] );
+
+		$synced_pattern_content_2 = '
+			<!-- wp:test/custom-block -->
+			<p data-bing="bang">My second synced pattern content</p>
+			<!-- /wp:test/custom-block -->
+		';
+
+		$synced_pattern_2 = $this->factory()->post->create_and_get( [
+			'post_content' => $synced_pattern_content_2,
+			'post_status'  => 'publish',
+			'post_type'    => 'wp_block',
+		] );
+
+		$html = sprintf( '
+		<!-- wp:block {"ref":%d} /-->
+		<!-- wp:block {"ref":%d} /-->
+		', $synced_pattern_1->ID, $synced_pattern_2->ID );
+
+		$expected_blocks = [
+			[
+				'name'        => 'core/block',
+				'attributes'  => [
+					'ref' => $synced_pattern_1->ID,
+				],
+				'innerBlocks' => [
+					[
+						'name'       => 'test/custom-block',
+						'attributes' => [
+							'content' => 'My first synced pattern content',
+							'bing'    => 'bong',
+						],
+					],
+				],
+			],
+			[
+				'name'        => 'core/block',
+				'attributes'  => [
+					'ref' => $synced_pattern_2->ID,
+				],
+				'innerBlocks' => [
+					[
+						'name'       => 'test/custom-block',
+						'attributes' => [
+							'content' => 'My second synced pattern content',
+							'bing'    => 'bang',
+						],
+					],
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertEquals( $expected_blocks, $blocks['blocks'], sprintf( 'Blocks not equal: %s', wp_json_encode( $blocks['blocks'] ) ) );
+	}
+
+	/* Synced pattern with override */
+
+	public function test_synced_pattern_with_override() {
+		$synced_pattern_content = '
+			<!-- wp:paragraph {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"my-override"}} -->
+			<p>Default content</p>
+			<!-- /wp:paragraph -->
+		';
+
+		$synced_pattern = $this->factory()->post->create_and_get( [
+			'post_content' => $synced_pattern_content,
+			'post_status'  => 'publish',
+			'post_type'    => 'wp_block',
+		] );
+
+		$html = sprintf( '
+		<!-- wp:block {"ref":%d,"content":{"my-override":{"content":"Overridden content"}}} /-->
+		', $synced_pattern->ID );
+
+		$post = $this->factory()->post->create_and_get();
+
+		$expected_blocks = [
+			[
+				'name'        => 'core/block',
+				'attributes'  => [
+					'ref' => $synced_pattern->ID,
+				],
+				'innerBlocks' => [
+					[
+						'name'       => 'core/paragraph',
+						'attributes' => [
+							'content'  => 'Overridden content', // Overridden by synced pattern override
+							'metadata' => [
+								'bindings' => [
+									'__default' => [
+										'source' => 'core/pattern-overrides',
+									],
+								],
+								'name'     => 'my-override',
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html, $post->ID );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+
+		// Because this test uses core blocks, we use assertArraySubset to avoid brittle
+		// tests when core block attributes change.
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
+		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
+		$this->assertEquals( 1, count( $blocks['blocks'][0]['innerBlocks'] ), 'Too many inner blocks in synced pattern' );
+	}
+
+	/* Multiple nested synced patterns with block bindings -- FINAL BOSS! */
+
+	public function test_multiple_nested_synced_patterns_with_block_bindings() {
+		$this->register_block_with_attributes( 'test/custom-container', [
+			'fizz' => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'div',
+				'attribute' => 'data-fizz',
+			],
+		] );
+
+		$this->register_block_with_attributes( 'test/custom-block', [
+			'content' => [
+				'type'               => 'rich-text',
+				'source'             => 'rich-text',
+				'selector'           => 'p',
+				'__experimentalRole' => 'content',
+			],
+			'bing'    => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'p',
+				'attribute' => 'data-bing',
+			],
+		] );
+
+		$synced_pattern_content_1 = '
+			<!-- wp:test/custom-block -->
+			<p data-bing="bong">My first synced pattern content</p>
+			<!-- /wp:test/custom-block -->
+
+			<!-- wp:core/paragraph {"metadata":{"bindings":{"content":{"source":"test/synced-pattern-block-binding","args":{"foo":"bar"}}}}} -->
+			<p>Fallback content</p>
+			<!-- /wp:core/paragraph -->
+
+			<!-- wp:paragraph {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"my-override"}} -->
+			<p>Default content</p>
+			<!-- /wp:paragraph -->
+		';
+
+		$synced_pattern_1 = $this->factory()->post->create_and_get( [
+			'post_content' => $synced_pattern_content_1,
+			'post_status'  => 'publish',
+			'post_type'    => 'wp_block',
+		] );
+
+		$synced_pattern_content_2 = sprintf( '
+			<!-- wp:test/custom-block -->
+			<p data-bing="bang">My second synced pattern content which contains the first</p>
+			<!-- /wp:test/custom-block -->
+
+			<!-- wp:block {"ref":%d} /-->
+
+			<!-- wp:test/custom-block -->
+			<p data-bing="bang">Another block to "wrap" the nested pattern</p>
+			<!-- /wp:test/custom-block -->
+		', $synced_pattern_1->ID );
+
+		$synced_pattern_2 = $this->factory()->post->create_and_get( [
+			'post_content' => $synced_pattern_content_2,
+			'post_status'  => 'publish',
+			'post_type'    => 'wp_block',
+		] );
+
+		// This uses the default post context. Custom block binding context is not
+		// yet supported inside synced patterns.
+		$this->register_block_bindings_source(
+			'test/synced-pattern-block-binding',
+			[
+				'label'              => 'Block binding inside synced pattern',
+				'get_value_callback' => static function ( array $args, WP_Block $block ) {
+					return sprintf( 'Block binding for %s with arg foo=%s in %s %d', $block->name, $args['foo'], $block->context['postType'] ?? 'unknown', $block->context['postId'] ?? 'unknown' );
+				},
+				'uses_context'       => [ 'postId', 'postType' ],
+			]
+		);
+
+		$html = sprintf( '
+		<!-- wp:test/custom-container -->
+		<div data-fizz="buzz">
+		<!-- wp:block {"ref":%d} /-->
+		</div>
+		<!-- /wp:test/custom-container -->
+
+		<!-- wp:test/custom-container -->
+		<div data-fizz="buzz">
+		<!-- wp:block {"ref":%d,"content":{"my-override":{"content":"Overridden content"}}} /-->
+		</div>
+		<!-- /wp:test/custom-container -->
+
+		<!-- wp:test/custom-container -->
+		<div data-fizz="bazz">
+		<!-- wp:block {"ref":%d} /-->
+		</div>
+		<!-- /wp:test/custom-container -->
+		', $synced_pattern_1->ID, $synced_pattern_1->ID, $synced_pattern_2->ID );
+
+		$post = $this->factory()->post->create_and_get();
+
+		$expected_blocks = [
+			[
+				'name'        => 'test/custom-container',
+				'attributes'  => [
+					'fizz' => 'buzz',
+				],
+				'innerBlocks' => [
+					[
+						'name'        => 'core/block',
+						'attributes'  => [
+							'ref' => $synced_pattern_1->ID,
+						],
+						'innerBlocks' => [
+							[
+								'name'       => 'test/custom-block',
+								'attributes' => [
+									'content' => 'My first synced pattern content',
+									'bing'    => 'bong',
+								],
+							],
+							[
+								'name'       => 'core/paragraph',
+								'attributes' => [
+									'content'  => sprintf( 'Block binding for core/paragraph with arg foo=bar in post %d', $post->ID ),
+									'metadata' => [
+										'bindings' => [
+											'content' => [
+												'source' => 'test/synced-pattern-block-binding',
+												'args'   => [ 'foo' => 'bar' ],
+											],
+										],
+									],
+								],
+							],
+							[
+								'name'       => 'core/paragraph',
+								'attributes' => [
+									'content'  => 'Default content',
+									'metadata' => [
+										'bindings' => [
+											'__default' => [
+												'source' => 'core/pattern-overrides',
+											],
+										],
+										'name'     => 'my-override',
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+			[
+				'name'        => 'test/custom-container',
+				'attributes'  => [
+					'fizz' => 'buzz',
+				],
+				'innerBlocks' => [
+					[
+						'name'        => 'core/block',
+						'attributes'  => [
+							'ref' => $synced_pattern_1->ID,
+						],
+						'innerBlocks' => [
+							[
+								'name'       => 'test/custom-block',
+								'attributes' => [
+									'content' => 'My first synced pattern content',
+									'bing'    => 'bong',
+								],
+							],
+							[
+								'name'       => 'core/paragraph',
+								'attributes' => [
+									'content'  => sprintf( 'Block binding for core/paragraph with arg foo=bar in post %d', $post->ID ),
+									'metadata' => [
+										'bindings' => [
+											'content' => [
+												'source' => 'test/synced-pattern-block-binding',
+												'args'   => [ 'foo' => 'bar' ],
+											],
+										],
+									],
+								],
+							],
+							[
+								'name'       => 'core/paragraph',
+								'attributes' => [
+									'content'  => 'Overridden content', // Overridden by synced pattern override
+									'metadata' => [
+										'bindings' => [
+											'__default' => [
+												'source' => 'core/pattern-overrides',
+											],
+										],
+										'name'     => 'my-override',
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+			[
+				'name'        => 'test/custom-container',
+				'attributes'  => [
+					'fizz' => 'bazz',
+				],
+				'innerBlocks' => [
+					[
+						'name'        => 'core/block',
+						'attributes'  => [
+							'ref' => $synced_pattern_2->ID,
+						],
+						'innerBlocks' => [
+							[
+								'name'       => 'test/custom-block',
+								'attributes' => [
+									'content' => 'My second synced pattern content which contains the first',
+									'bing'    => 'bang',
+								],
+							],
+							[
+								'name'        => 'core/block',
+								'attributes'  => [
+									'ref' => $synced_pattern_1->ID,
+								],
+								'innerBlocks' => [
+									[
+										'name'       => 'test/custom-block',
+										'attributes' => [
+											'content' => 'My first synced pattern content',
+											'bing'    => 'bong',
+										],
+									],
+									[
+										'name'       => 'core/paragraph',
+										'attributes' => [
+											'content'  => sprintf( 'Block binding for core/paragraph with arg foo=bar in post %d', $post->ID ),
+											'metadata' => [
+												'bindings' => [
+													'content' => [
+														'source' => 'test/synced-pattern-block-binding',
+														'args'   => [ 'foo' => 'bar' ],
+													],
+												],
+											],
+										],
+									],
+									[
+										'name'       => 'core/paragraph',
+										'attributes' => [
+											'content'  => 'Default content',
+											'metadata' => [
+												'bindings' => [
+													'__default' => [
+														'source' => 'core/pattern-overrides',
+													],
+												],
+												'name'     => 'my-override',
+											],
+										],
+									],
+								],
+							],
+							[
+								'name'       => 'test/custom-block',
+								'attributes' => [
+									'content' => 'Another block to "wrap" the nested pattern',
+									'bing'    => 'bang',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html, $post->ID );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+
+		// Because this test uses core blocks, we use assertArraySubset to avoid brittle
+		// tests when core block attributes change.
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
+		$this->assertEquals( 3, count( $blocks['blocks'] ), 'Too many blocks in result set' );
+
+		// First synced pattern
+		$this->assertEquals( 1, count( $blocks['blocks'][0]['innerBlocks'] ), 'Too many inner blocks in first container block' );
+		$this->assertEquals( 3, count( $blocks['blocks'][0]['innerBlocks'][0]['innerBlocks'] ), 'Too many inner blocks in first synced pattern' );
+
+		// First synced pattern, repeated (contains pattern override)
+		$this->assertEquals( 1, count( $blocks['blocks'][1]['innerBlocks'] ), 'Too many inner blocks in first container block' );
+		$this->assertEquals( 3, count( $blocks['blocks'][1]['innerBlocks'][0]['innerBlocks'] ), 'Too many inner blocks in first synced pattern' );
+
+		// Second synced pattern
+		$this->assertEquals( 1, count( $blocks['blocks'][2]['innerBlocks'] ), 'Too many inner blocks in second container block' );
+		$this->assertEquals( 3, count( $blocks['blocks'][2]['innerBlocks'][0]['innerBlocks'] ), 'Too many inner blocks in second synced pattern' );
+		$this->assertEquals( 3, count( $blocks['blocks'][2]['innerBlocks'][0]['innerBlocks'][1]['innerBlocks'] ), 'Too many inner blocks in nested pattern in second synced pattern' );
+	}
+}

--- a/vip-block-data-api.php
+++ b/vip-block-data-api.php
@@ -40,6 +40,7 @@ if ( ! defined( 'VIP_BLOCK_DATA_API_LOADED' ) ) {
 
 	// Block parsing.
 	require_once __DIR__ . '/src/parser/content-parser.php';
+	require_once __DIR__ . '/src/parser/block-additions/core-block.php';
 	require_once __DIR__ . '/src/parser/block-additions/core-image.php';
 
 	// Analytics.


### PR DESCRIPTION
## Description

Add support for synced patterns (previously known as "reusable blocks"). Synced patterns are implemented as a dynamic block (`core/block`) and currently result in a dead end in the API output:

```json
{
  "blocks": [
    {
      "name": "core/block",
      "attributes": {
        "ref": 6
      }
    }
  ]
}
```

However that `ref` is a pointer to a `wp_block` post, where the blocks (and potential block data) is stored. This PR adds support for loading those blocks:

```json
{
  "blocks": [
    {
      "name": "core/block",
      "attributes": {
        "ref": 6
      },
      "innerBlocks": [
        {
          "name": "core/paragraph",
          "attributes": {
            "content": "This is a block stored in a synced pattern!"
          }
        }
      ]
    }
  ]
}
```

Setting aside tests and comments, the diff here is only about 150 LOC. Its primary features are:

- Add two new actions and one filter that allow the `CoreBlock` class to hook into the parser. These hooks are documented in the README.
- Hook into the core render cycle so that we can capture the inner blocks of synced patterns and inject them as the parser walks the tree.
- Provide support for important core features and use cases, including:
  - Multiple nested synced patterns
  - Block bindings inside synced patterns
  - Synced pattern overrides (itself a special kind of block binding)

The `CoreBlock` does some fairly advanced filtering but is well-documented in the comments. Likewise, the tests are fairly extensive but feel free to suggest additional cases.
