### PR TITLE
Fix iterator_to_array() error on PHP < 8.2

### DIFF
--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -297,7 +297,11 @@ class ContentParser {
 		];
 
 		// WP_Block#inner_blocks can be an array or WP_Block_List (iterable).
-		$inner_blocks = iterator_to_array( $block->inner_blocks );
+		if ( is_array( $block->inner_blocks ) ) {
+			$inner_blocks = $block->inner_blocks;
+		} else {
+			$inner_blocks = iterator_to_array( $block->inner_blocks );
+		}
 
 		/**
 		 * Filters a block's inner blocks before recursive iteration.

--- a/vip-block-data-api.php
+++ b/vip-block-data-api.php
@@ -5,7 +5,7 @@
  * Description: Access Gutenberg block data in JSON via the REST API.
  * Author: WordPress VIP
  * Text Domain: vip-block-data-api
- * Version: 1.4.0
+ * Version: 1.4.1
  * Requires at least: 6.0
  * Tested up to: 6.6
  * Requires PHP: 8.0
@@ -20,7 +20,7 @@ namespace WPCOMVIP\BlockDataApi;
 if ( ! defined( 'VIP_BLOCK_DATA_API_LOADED' ) ) {
 	define( 'VIP_BLOCK_DATA_API_LOADED', true );
 
-	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '1.4.0' );
+	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '1.4.1' );
 	define( 'WPCOMVIP__BLOCK_DATA_API__REST_ROUTE', 'vip-block-data-api/v1' );
 
 	// Analytics related configs.


### PR DESCRIPTION
## Description

Fixes https://github.com/Automattic/vip-block-data-api/issues/77, which causes this error:

> ```json
> {
>   "code": "vip-block-data-api-parser-error",
>   "message": "Error parsing post ID 2: iterator_to_array(): Argument #1 ($iterator) must be of type Traversable, array given",
>   "data": {
>     "status": 500
>   }
> }
> ```

This is caused by a call to `iterator_to_array()` in parser code:

https://github.com/Automattic/vip-block-data-api/blob/1593b60b84a91d61845e19c847e8166c1f0e0c6c/src/parser/content-parser.php#L299-L300

[`iterator_to_array()`](https://www.php.net/manual/en/function.iterator-to-array.php) will only accept an array in PHP 8.2.

![PHP Changelog for iterator_to_array() showing 8.2 change](https://github.com/user-attachments/assets/5414bbdc-d5df-41be-9b04-f2df1b7a31b0)

Our plugin supports to PHP 8.0, which means 8.0 and 8.1 will currently show this error for any parsed post.

The changed code now tests for an array and uses it directly if available, which will work on prior PHP versions.

## Steps to Test

1. Check out the `trunk` branch of `vip-block-data-api` and install on a WordPress installation with PHP version `8.0` or `8.1`.
2. Go to a published post's Block Data API URL, e.g.

    ```
    https://my.lndo.site/wp-json/vip-block-data-api/v1/posts/1/blocks
    ```

3. See the iterator error in the response data: `Error parsing post ID 1: iterator_to_array(): Argument #1 ($iterator) must be of type Traversable, array given`.
4. Change the VIP Block Data API branch to this branch (`fix/php-8.1-iterator-error`).
5. Reload the `wp-json` endpoint used in step 2.
6. See that the post renders correctly.

## Other Todos

- [x] ~Figure out why the [minimum test matrix](https://github.com/Automattic/vip-workflow-plugin/blob/b45b565b49be4c21d5511cb79e927c06c463bc83/.github/workflows/php-tests.yml#L20-L23) (PHP 8/WordPress 6.2) didn't catch this.~

    See https://github.com/Automattic/vip-block-data-api/pull/79.
- [x] Ensure this fix is included in the next update of VIP's integrations.