### PR TITLE
Fix wp-env to use proper PHP version in test matrix

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -21,6 +21,10 @@ jobs:
           - php: "8.0"
             wp: "6.0"
             allowed_failure: false
+          # Check latest WP with the lowest supported PHP.
+          - php: "8.0"
+            wp: "master"
+            allowed_failure: false
           # Check latest WP with the highest supported PHP.
           - php: "latest"
             wp: "master"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -52,6 +52,7 @@ jobs:
         run: wp-env start
         env:
           WP_ENV_CORE: WordPress/WordPress#${{ matrix.wp }}
+          WP_ENV_PHP_VERSION: ${{ matrix.php }}
 
       - name: PHPUnit
         run: composer test

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -26,7 +26,7 @@ jobs:
             wp: "master"
             allowed_failure: false
           # Check latest WP with the highest supported PHP.
-          - php: "latest"
+          - php: "8"
             wp: "master"
             allowed_failure: false
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -26,7 +26,7 @@ jobs:
             wp: "master"
             allowed_failure: false
           # Check latest WP with the highest supported PHP.
-          - php: "8"
+          - php: "8.3"
             wp: "master"
             allowed_failure: false
 


### PR DESCRIPTION
## Description

See https://github.com/Automattic/vip-block-data-api/pull/78, which addresses a bug in `1.4.0` that should have caused test failures due to a regression. The cause of the issue is that our test matrix PHP version was being used only partially to setup depedencies and run composer:

https://github.com/Automattic/vip-block-data-api/blob/1593b60b84a91d61845e19c847e8166c1f0e0c6c/.github/workflows/phpunit.yml#L36-L40

but not explicitly passed to `wp-env`:

https://github.com/Automattic/vip-block-data-api/blob/1593b60b84a91d61845e19c847e8166c1f0e0c6c/.github/workflows/phpunit.yml#L47-L50

This PR addresses these issues:

- We now pass the WordPress PHP version via `WP_ENV_PHP_VERSION`.
- We've added an additional test test with PHP 8.0 and the latest version of WordPress, which may catch similar PHP-related changes in recent versions of WordPress features.
- The PHP "latest" option [doesn't work](https://github.com/Automattic/vip-block-data-api/actions/runs/10798196163/job/29951165023#step:6:13) with `wp-env` as an option for `WP_ENV_PHP_VERSION`:

    ```
    ✖ Invalid environment variable: "WP_ENV_PHP_VERSION" must be a string of the format "X", "X.X", or "X.X.X".
    ```

    We're passing `8.3` explicitly instead. We'll want to keep this up to date with newer PHP versions, but this is a helpful guide for our highest tested version, which we did not explicitly test before.