### PR TITLE
Add min php and wp notice

### DIFF
--- a/vip-block-data-api.php
+++ b/vip-block-data-api.php
@@ -5,7 +5,7 @@
  * Description: Access Gutenberg block data in JSON via the REST API.
  * Author: WordPress VIP
  * Text Domain: vip-block-data-api
- * Version: 1.4.1
+ * Version: 1.4.2
  * Requires at least: 6.0
  * Tested up to: 6.6
  * Requires PHP: 8.0
@@ -33,7 +33,7 @@ if ( ! defined( 'VIP_BLOCK_DATA_API_LOADED' ) ) {
 		return;
 	}
 
-	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '1.4.1' );
+	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '1.4.2' );
 	define( 'WPCOMVIP__BLOCK_DATA_API__REST_ROUTE', 'vip-block-data-api/v1' );
 
 	// Analytics related configs.

--- a/vip-block-data-api.php
+++ b/vip-block-data-api.php
@@ -20,6 +20,19 @@ namespace WPCOMVIP\BlockDataApi;
 if ( ! defined( 'VIP_BLOCK_DATA_API_LOADED' ) ) {
 	define( 'VIP_BLOCK_DATA_API_LOADED', true );
 
+	// ToDo: When 6.4 is our min version, switch to wp_admin_notice.
+	global $wp_version;
+	if ( version_compare( phpversion(), '8.0', '<' ) || version_compare( $wp_version, '6.0', '<' ) ) {
+		add_action( 'admin_notices', function () {
+			?>
+			<div class="notice notice-error">
+					<p><?php esc_html_e( 'VIP Block Data API requires PHP 8.0+ and WordPress 6.0+.', 'vip-block-data-api' ); ?></p>
+				</div>
+			<?php
+		}, 10, 0 );
+		return;
+	}
+
 	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '1.4.1' );
 	define( 'WPCOMVIP__BLOCK_DATA_API__REST_ROUTE', 'vip-block-data-api/v1' );
 


### PR DESCRIPTION
## Description

I realized we don't have a PHP and WP version check and the one we have been relying won't really be enforced for the way we expect this plugin to be deployed. So I have added in a manual check, akin to what we have in the workflow plugin.

This is already what the plugin supports so it's just matching that.

## Steps to Test

Either load a WP version prior to 6.0 with PHP version lower than 8.0, or change those numbers to something arbitrary and see it fail.

