### PR TITLE
Fix raw attribute sources with multiple nodes

### DIFF
--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -680,10 +680,15 @@ class ContentParser {
 		// Also see tag attribute parsing in Gutenberg:
 		// https://github.com/WordPress/gutenberg/blob/6517008/packages/blocks/src/api/parser/get-block-attributes.js#L131
 
-		$attribute_value = null;
-
 		if ( $crawler->count() > 0 ) {
-			$attribute_value = trim( $crawler->outerHtml() );
+			// $crawler's outerHtml() will only return the HTML of the first node in this raw HTML.
+			// If the raw HTML contains multiple top-level nodes, we need to use the inner HTML of the wrapping
+			// 'body' tag. This will also preserve internal whitespace in the HTML.
+			$body_node = $crawler->closest( 'body' );
+
+			if ( $body_node && $body_node->count() > 0 ) {
+				$attribute_value = trim( $body_node->html() );
+			}
 		}
 
 		return $attribute_value;

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -680,6 +680,8 @@ class ContentParser {
 		// Also see tag attribute parsing in Gutenberg:
 		// https://github.com/WordPress/gutenberg/blob/6517008/packages/blocks/src/api/parser/get-block-attributes.js#L131
 
+		$attribute_value = null;
+
 		if ( $crawler->count() > 0 ) {
 			// $crawler's outerHtml() will only return the HTML of the first node in this raw HTML.
 			// If the raw HTML contains multiple top-level nodes, we need to use the inner HTML of the wrapping

--- a/tests/parser/sources/test-source-raw.php
+++ b/tests/parser/sources/test-source-raw.php
@@ -79,4 +79,32 @@ class SourceRawTest extends RegistryTestCase {
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
 	}
+
+	public function test_parse_raw_source_multiple_top_level_nodes() {
+		$this->register_block_with_attributes( 'test/html', [
+			'content' => [
+				'type'   => 'string',
+				'source' => 'raw',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/html -->
+			<p>Node 1</p><p>Node 2</p>
+			<!-- /wp:test/html -->';
+
+		$expected_blocks = [
+			[
+				'name'       => 'test/html',
+				'attributes' => [
+					'content' => '<p>Node 1</p><p>Node 2</p>',
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
+	}
 }

--- a/tests/parser/sources/test-source-raw.php
+++ b/tests/parser/sources/test-source-raw.php
@@ -107,4 +107,33 @@ class SourceRawTest extends RegistryTestCase {
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
 	}
+
+	public function test_parse_raw_source_multiple_top_level_nodes_with_whitespace() {
+		$this->register_block_with_attributes( 'test/html', [
+			'content' => [
+				'type'   => 'string',
+				'source' => 'raw',
+			],
+		] );
+
+		$html = '
+			<!-- wp:test/html -->
+			<span class="highlight">This</span> <span>should</span> <span>retain</span>&nbsp;<span>inner</span>
+<span>whitespace</span>
+			<!-- /wp:test/html -->';
+
+		$expected_blocks = [
+			[
+				'name'       => 'test/html',
+				'attributes' => [
+					'content' => "<span class=\"highlight\">This</span> <span>should</span> <span>retain</span>&nbsp;<span>inner</span>\n<span>whitespace</span>",
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
+	}
 }


### PR DESCRIPTION
## Description

See https://github.com/Automattic/vip-block-data-api/issues/81 for a description of the problem. In short, if a block with a raw source like `core/html` has multiple top-level nodes, the Block Data API returns only the HTML of the first node.

Block HTML:

```
<!-- wp:html -->
<h1>First node</h1><h2>Second node</h2>
<!-- /wp:html -->
```

Incorrect output:

```json
{
    "name": "core/html",
    "attributes": {
        "content": "<h1>First node</h1>"
    }
}
```

The `source_block_raw` function responsible for gathering this HTML has been changed to use the parent wrapper block's inner HTML. This will collect all node HTML as well as preserving inner whitespace in the HTML content.

## Steps to Test

1. Check out PR.
1. Run `wp-env start` and `composer install`.
1. Run `composer run test`
1. See successful tests.
