### PR TITLE
Test for the targeted attribute, not the `__default` alias

### DIFF
--- a/tests/parser/test-synced-patterns.php
+++ b/tests/parser/test-synced-patterns.php
@@ -199,7 +199,7 @@ class SyncedPatternsTest extends RegistryTestCase {
 							'content'  => 'Overridden content', // Overridden by synced pattern override
 							'metadata' => [
 								'bindings' => [
-									'__default' => [
+									'content' => [
 										'source' => 'core/pattern-overrides',
 									],
 								],
@@ -366,7 +366,7 @@ class SyncedPatternsTest extends RegistryTestCase {
 									'content'  => 'Default content',
 									'metadata' => [
 										'bindings' => [
-											'__default' => [
+											'content' => [
 												'source' => 'core/pattern-overrides',
 											],
 										],
@@ -417,7 +417,7 @@ class SyncedPatternsTest extends RegistryTestCase {
 									'content'  => 'Overridden content', // Overridden by synced pattern override
 									'metadata' => [
 										'bindings' => [
-											'__default' => [
+											'content' => [
 												'source' => 'core/pattern-overrides',
 											],
 										],
@@ -481,7 +481,7 @@ class SyncedPatternsTest extends RegistryTestCase {
 											'content'  => 'Default content',
 											'metadata' => [
 												'bindings' => [
-													'__default' => [
+													'content' => [
 														'source' => 'core/pattern-overrides',
 													],
 												],


### PR DESCRIPTION
## Description

[This commit](https://github.com/WordPress/WordPress/commit/23e8ce70f00530332ed5efe50b4d0c20245bb7c1) introduced a change to parsed block bindings. It no longer provides the binding under the `__default` alias and instead only provides the actual targeted attribute (e.g., `content` for a `core/paragraph` block).

To be honest, this is a better result for Block Data API consumers, because they are not exposed to an alias that they would need to resolve themselves. Although, to be clear, this is all very theoretical. It is highly unlikely that any API consumers would inspect the bindings at all, which live in the `metadata` attribute. Almost certainly, they are only interested in the actual attribute value (e.g., `content`), which is unchanged.