### PR TITLE
Bump latest supported WordPress version to 6.7

### DIFF
--- a/vip-block-data-api.php
+++ b/vip-block-data-api.php
@@ -5,9 +5,9 @@
  * Description: Access Gutenberg block data in JSON via the REST API.
  * Author: WordPress VIP
  * Text Domain: vip-block-data-api
- * Version: 1.4.2
+ * Version: 1.4.3
  * Requires at least: 6.0
- * Tested up to: 6.6
+ * Tested up to: 6.7
  * Requires PHP: 8.0
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -33,7 +33,7 @@ if ( ! defined( 'VIP_BLOCK_DATA_API_LOADED' ) ) {
 		return;
 	}
 
-	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '1.4.2' );
+	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '1.4.3' );
 	define( 'WPCOMVIP__BLOCK_DATA_API__REST_ROUTE', 'vip-block-data-api/v1' );
 
 	// Analytics related configs.


### PR DESCRIPTION
## Description

Tested with the latest WordPress release candidate for WordPress 6.7. Bump our latest `Tested up to:` version.