### PR TITLE
Correctly parse synced patterns with nested blocks

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Cache Composer packages
         id: composer-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/src/parser/block-additions/core-block.php
+++ b/src/parser/block-additions/core-block.php
@@ -10,10 +10,11 @@ namespace WPCOMVIP\BlockDataApi\ContentParser\BlockAdditions;
 defined( 'ABSPATH' ) || die();
 
 use WP_Block;
-use WP_Block_Supports;
-use function add_action;
+use WPCOMVIP\BlockDataApi\ContentParser;
+
 use function add_filter;
-use function remove_filter;
+use function get_post;
+use function parse_blocks;
 
 /**
  * Enhance core/block block by capturing its inner blocks.
@@ -27,58 +28,21 @@ class CoreBlock {
 	private static $block_name = 'core/block';
 
 	/**
-	 * A store of captured inner blocks. See `capture_inner_blocks`.
-	 *
-	 * @var array
-	 *
-	 * @access private
-	 */
-	protected static $captured_inner_blocks = [];
-
-	/**
 	 * Initialize the CoreBlock class.
 	 *
 	 * @access private
 	 */
 	public static function init(): void {
-		add_action( 'vip_block_data_api__before_block_render', [ __CLASS__, 'setup_before_render' ], 10, 0 );
-		add_action( 'vip_block_data_api__after_block_render', [ __CLASS__, 'cleanup_after_render' ], 10, 0 );
-		add_filter( 'vip_block_data_api__sourced_block_inner_blocks', [ __CLASS__, 'get_inner_blocks' ], 5, 4 );
+		add_filter( 'vip_block_data_api__sourced_block_inner_blocks', [ __CLASS__, 'get_inner_blocks' ], 5, 5 );
 		add_filter( 'vip_block_data_api__sourced_block_result', [ __CLASS__, 'remove_content_array' ], 5, 2 );
 	}
 
 	/**
-	 * Setup before render.
-	 */
-	public static function setup_before_render(): void {
-		/**
-		 * Hook into the `render_block` filter, which is near the end of WP_Block#render().
-		 * This allows us to capture the inner blocks of synced patterns ("core/block").
-		 * See `capture_inner_blocks`.
-		 */
-		add_filter( 'render_block', [ __CLASS__, 'capture_inner_blocks' ], 10, 3 );
-	}
-
-	/**
-	 * Cleanup after render.
-	 */
-	public static function cleanup_after_render() {
-		self::$captured_inner_blocks = [];
-		remove_filter( 'render_block', [ __CLASS__, 'capture_inner_blocks' ], 10 );
-	}
-
-	/**
-	 * Capture the inner blocks of synced patterns during block rendering. Intended
-	 * for use with the `render_block` filter.
+	 * Get the inner blocks of a synced pattern / reusable block. Intended for use
+	 * with the `vip_block_data_api__sourced_block_inner_blocks` filter.
 	 *
-	 * We have no intention of filtering the rendered block content, but this hook
-	 * is conveniently located near the end of WP_Block#render() after block
-	 * processing is finished. We get access to the parent block via the global
-	 * static class `WP_Block_Supports`.
-	 *
-	 * This approach is necessary because synced patterns (core/block) are dynamic
-	 * blocks, and core's method of rendering dynamic blocks severs the connection
-	 * between the parent block and its inner blocks:
+	 * Synced patterns are dynamic blocks, and core's method of rendering dynamic
+	 * blocks severs the connection between the parent block and its inner blocks:
 	 *
 	 * https://github.com/WordPress/WordPress/blob/6.6.1/wp-includes/class-wp-block.php#L519
 	 *
@@ -88,105 +52,42 @@ class CoreBlock {
 	 * missing from the Block Data API. Capturing synced pattern content as inner
 	 * blocks is extremely useful and avoids the need for additional API calls.
 	 *
-	 * @param string   $block_content Rendered block content.
-	 * @param array    $parsed_block  Parsed block data.
-	 * @param WP_Block $block         Block instance.
-	 * @return string
-	 */
-	public static function capture_inner_blocks( string $block_content, array $parsed_block, WP_Block $block ): string {
-		// If this block is a synced pattern, that means it is finished rendering.
-		// Lock its inner blocks to prevent further captures in case it is rendered
-		// elsewhere in the tree.
-		if ( self::$block_name === $block->name ) {
-			$store_key = self::get_store_key( $parsed_block );
-			if ( isset( self::$captured_inner_blocks[ $store_key ] ) ) {
-				self::$captured_inner_blocks[ $store_key ]['locked'] = true;
-			}
-		}
-
-		// Get the parent block that is currently being rendered. This is fragile,
-		// but is currently the only way we can get access to the parent block from
-		// inside a dynamic block's render callback function.
-		//
-		// https://github.com/WordPress/WordPress/blob/6.6.1/wp-includes/class-wp-block.php#L517
-		$parent_block = isset( WP_Block_Supports::$block_to_render ) ? WP_Block_Supports::$block_to_render : [];
-
-		// If the parent block is not a synced pattern, do nothing.
-		if ( ! isset( $parent_block['attrs']['ref'] ) || self::$block_name !== $parent_block['blockName'] ) {
-			return $block_content;
-		}
-
-		// Capture the inner block for this synced pattern.
-		self::capture_inner_block( $parent_block, $block );
-
-		return $block_content;
-	}
-
-	/**
-	 * Get captured inner blocks for synced patterns. Intended for use with
-	 * the `vip_block_data_api__sourced_block_inner_blocks` filter.
+	 * This requires us to reimplement some logic from `render_block_core_block()`:
+	 *
+	 * https://github.com/WordPress/WordPress/blob/6.6.1/wp-includes/blocks/block.php#L19
 	 *
 	 * @param array    $inner_blocks Inner blocks.
 	 * @param string   $block_name   Block name.
-	 * @param int|null $_post_id     Post ID (unused).
+	 * @param int|null $post_id      Post ID.
 	 * @param array    $parsed_block Parsed block data.
 	 * @return array
 	 */
-	public static function get_inner_blocks( array $inner_blocks, string $block_name, int|null $_post_id, array $parsed_block ): array {
+	public static function get_inner_blocks( array $inner_blocks, string $block_name, int|null $post_id, array $parsed_block ): array {
+		// Not a synced pattern? Return the inner blocks unchanged.
 		if ( self::$block_name !== $block_name || ! isset( $parsed_block['attrs']['ref'] ) ) {
 			return $inner_blocks;
 		}
 
-		$store_key = self::get_store_key( $parsed_block );
+		$context = [];
 
-		if ( ! isset( self::$captured_inner_blocks[ $store_key ] ) ) {
-			return $inner_blocks;
+		// Support synced pattern overrides. Copied and adapted from core:
+		// https://github.com/WordPress/WordPress/blob/6.6.1/wp-includes/blocks/block.php#L81
+		//
+		// In our case, we don't need to filter the context since we can pass it in.
+		if ( isset( $parsed_block['attrs']['content'] ) ) {
+			$context['pattern/overrides'] = $parsed_block['attrs']['content'];
 		}
 
-		return self::$captured_inner_blocks[ $store_key ]['inner_blocks'];
-	}
+		// Load, parse, and render the inner blocks of the synced pattern, passing
+		// along its block context. We intentionally do not recursively call
+		// ContentParser->parse() to avoid calling telemetry and filters again.
+		$parser = new ContentParser();
+		$post   = get_post( $parsed_block['attrs']['ref'] );
+		$blocks = parse_blocks( $post->post_content );
 
-	/**
-	 * Create a unique key that can be used to identify a synced pattern. This
-	 * allows us to store and retrieve inner blocks for synced patterns and avoid
-	 * duplication when they are used multiple times within the same tree.
-	 *
-	 * Using a hash of attributes is important because they may contain synced
-	 * pattern overrides, which can change the inner block content. The attributes
-	 * contain the synced pattern post ID, so uniqueness is built-in.
-	 *
-	 * @param array $parsed_block Parsed block data.
-	 * @return string
-	 */
-	protected static function get_store_key( array $parsed_block ): string {
-		// Include the synced pattern ID in the key just for legibility.
-		$synced_pattern_id = $parsed_block['attrs']['ref'] ?? null;
-		$attribute_json    = wp_json_encode( $parsed_block['attrs'] );
-
-		return sprintf( '%s_%s', strval( $synced_pattern_id ), sha1( $attribute_json ) );
-	}
-
-	/**
-	 * Capture inner block for a synced pattern.
-	 *
-	 * @param array    $synced_pattern Synced pattern block (parsed block).
-	 * @param WP_Block $block          Inner block.
-	 */
-	protected static function capture_inner_block( array $synced_pattern, WP_Block $block ): void {
-		$store_key = self::get_store_key( $synced_pattern );
-		if ( ! isset( self::$captured_inner_blocks[ $store_key ] ) ) {
-			self::$captured_inner_blocks[ $store_key ] = [
-				'inner_blocks' => [],
-				'locked'       => false,
-			];
-		}
-
-		// This pattern has already been rendered somewhere in the tree and is now locked.
-		if ( self::$captured_inner_blocks[ $store_key ]['locked'] ) {
-			return;
-		}
-
-		self::$captured_inner_blocks[ $store_key ]['inner_blocks'][] = $block;
+		return array_map( function ( array $block ) use ( $parser, $context, $post_id ): WP_Block {
+			return $parser->render_parsed_block( $block, $post_id, $context );
+		}, $blocks );
 	}
 
 	/**

--- a/src/parser/block-additions/core-block.php
+++ b/src/parser/block-additions/core-block.php
@@ -83,6 +83,11 @@ class CoreBlock {
 		// ContentParser->parse() to avoid calling telemetry and filters again.
 		$parser = new ContentParser();
 		$post   = get_post( $parsed_block['attrs']['ref'] );
+
+		if ( ! $post instanceof \WP_Post ) {
+			return [];
+		}
+
 		$blocks = parse_blocks( $post->post_content );
 
 		return array_map( function ( array $block ) use ( $parser, $context, $post_id ): WP_Block {

--- a/src/parser/block-additions/core-block.php
+++ b/src/parser/block-additions/core-block.php
@@ -10,6 +10,7 @@ namespace WPCOMVIP\BlockDataApi\ContentParser\BlockAdditions;
 defined( 'ABSPATH' ) || die();
 
 use WP_Block;
+use WP_Post;
 use WPCOMVIP\BlockDataApi\ContentParser;
 
 use function add_filter;
@@ -84,7 +85,7 @@ class CoreBlock {
 		$parser = new ContentParser();
 		$post   = get_post( $parsed_block['attrs']['ref'] );
 
-		if ( ! $post instanceof \WP_Post ) {
+		if ( ! $post instanceof WP_Post ) {
 			return [];
 		}
 

--- a/tests/parser/test-synced-patterns.php
+++ b/tests/parser/test-synced-patterns.php
@@ -226,6 +226,273 @@ class SyncedPatternsTest extends RegistryTestCase {
 		$this->assertEquals( 1, count( $blocks['blocks'][0]['innerBlocks'] ), 'Too many inner blocks in synced pattern' );
 	}
 
+	/* Synced pattern with deeply nested content */
+
+	public function test_synced_pattern_with_deeply_nested_content() {
+		$synced_pattern_content = '
+			<!-- wp:group -->
+			<div class="wp-block-group">
+				<!-- wp:group -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph -->
+					<p>Nested synced pattern content</p>
+					<!-- /wp:paragraph -->
+					<!-- wp:group -->
+					<div class="wp-block-group">
+						<!-- wp:group -->
+						<div class="wp-block-group">
+							<!-- wp:paragraph -->
+							<p>Deeply nested synced pattern content</p>
+							<!-- /wp:paragraph -->
+						</div>
+						<!-- /wp:group -->
+					</div>
+					<!-- /wp:group -->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:group -->
+		';
+
+		$synced_pattern = $this->factory()->post->create_and_get( [
+			'post_content' => $synced_pattern_content,
+			'post_status'  => 'publish',
+			'post_type'    => 'wp_block',
+		] );
+
+		$html = sprintf( '<!-- wp:block {"ref":%d} /-->', $synced_pattern->ID );
+
+		$expected_blocks = [
+			[
+				'name'        => 'core/block',
+				'attributes'  => [
+					'ref' => $synced_pattern->ID,
+				],
+				'innerBlocks' => [
+					[
+						'name'        => 'core/group',
+						'attributes'  => [
+							'tagName' => 'div',
+						],
+						'innerBlocks' => [
+							[
+								'name'        => 'core/group',
+								'attributes'  => [
+									'tagName' => 'div',
+								],
+								'innerBlocks' => [
+									[
+										'name'       => 'core/paragraph',
+										'attributes' => [
+											'content' => 'Nested synced pattern content',
+										],
+									],
+									[
+										'name'        => 'core/group',
+										'attributes'  => [
+											'tagName' => 'div',
+										],
+										'innerBlocks' => [
+											[
+												'name' => 'core/group',
+												'attributes' => [
+													'tagName' => 'div',
+												],
+												'innerBlocks' => [
+													[
+														'name'       => 'core/paragraph',
+														'attributes' => [
+															'content' => 'Deeply nested synced pattern content',
+														],
+													],
+												],
+											],
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+
+		// Core block attributes can change, so we use assertArraySubset to avoid
+		// brittle assertions.
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
+		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
+		$this->assertEquals( 1, count( $blocks['blocks'][0]['innerBlocks'] ), 'Too many inner blocks in synced pattern' );
+	}
+
+	/* Synced pattern with sourced attributen nested content */
+
+	public function test_synced_pattern_with_sourced_attribute_in_nested_content() {
+		$this->register_block_with_attributes( 'test/custom-block', [
+			'content' => [
+				'type'               => 'rich-text',
+				'source'             => 'rich-text',
+				'selector'           => 'p',
+				'__experimentalRole' => 'content',
+			],
+			'bing'    => [
+				'type'      => 'string',
+				'source'    => 'attribute',
+				'selector'  => 'p',
+				'attribute' => 'data-bing',
+			],
+		] );
+
+		$synced_pattern_content = '
+			<!-- wp:group -->
+			<div class="wp-block-group">
+				<!-- wp:group -->
+				<div class="wp-block-group">
+					<!-- wp:test/custom-block -->
+					<p data-bing="bong">My nested synced pattern content</p>
+					<!-- /wp:test/custom-block -->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:group -->
+		';
+
+		$synced_pattern = $this->factory()->post->create_and_get( [
+			'post_content' => $synced_pattern_content,
+			'post_status'  => 'publish',
+			'post_type'    => 'wp_block',
+		] );
+
+		$html = sprintf( '<!-- wp:block {"ref":%d} /-->', $synced_pattern->ID );
+
+		$expected_blocks = [
+			[
+				'name'        => 'core/block',
+				'attributes'  => [
+					'ref' => $synced_pattern->ID,
+				],
+				'innerBlocks' => [
+					[
+						'name'        => 'core/group',
+						'attributes'  => [
+							'tagName' => 'div',
+						],
+						'innerBlocks' => [
+							[
+								'name'        => 'core/group',
+								'attributes'  => [
+									'tagName' => 'div',
+								],
+								'innerBlocks' => [
+									[
+										'name'       => 'test/custom-block',
+										'attributes' => [
+											'content' => 'My nested synced pattern content',
+											'bing'    => 'bong',
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertEquals( $expected_blocks, $blocks['blocks'], sprintf( 'Blocks not equal: %s', wp_json_encode( $blocks['blocks'] ) ) );
+	}
+
+	/* Synced pattern with override in nested content */
+
+	public function test_synced_pattern_with_override_in_nested_content() {
+		$synced_pattern_content = '
+			<!-- wp:group -->
+			<div class=k"wp-block-group">
+				<!-- wp:group -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"my-override"}} -->
+					<p>Default content</p>
+					<!-- /wp:paragraph -->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:group -->
+		';
+
+		$synced_pattern = $this->factory()->post->create_and_get( [
+			'post_content' => $synced_pattern_content,
+			'post_status'  => 'publish',
+			'post_type'    => 'wp_block',
+		] );
+
+		$html = sprintf( '
+		<!-- wp:block {"ref":%d,"content":{"my-override":{"content":"Overridden content"}}} /-->
+		', $synced_pattern->ID );
+
+		$expected_blocks = [
+			[
+				'name'        => 'core/block',
+				'attributes'  => [
+					'ref' => $synced_pattern->ID,
+				],
+				'innerBlocks' => [
+					[
+						'name'        => 'core/group',
+						'attributes'  => [
+							'tagName' => 'div',
+						],
+						'innerBlocks' => [
+							[
+								'name'        => 'core/group',
+								'attributes'  => [
+									'tagName' => 'div',
+								],
+								'innerBlocks' => [
+									[
+										'name'       => 'core/paragraph',
+										'attributes' => [
+											'content'  => 'Overridden content', // Overridden by synced pattern override
+											'metadata' => [
+												'bindings' => [
+													'content' => [
+														'source' => 'core/pattern-overrides',
+													],
+												],
+												'name'     => 'my-override',
+											],
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+
+		// Block bindings are currently only supported for specific core blocks.
+		// https://make.wordpress.org/core/2024/03/06/new-feature-the-block-bindings-api/
+		//
+		// Core block attributes can change, so we use assertArraySubset to avoid
+		// brittle assertions.
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], false, wp_json_encode( $blocks['blocks'] ) );
+		$this->assertEquals( 1, count( $blocks['blocks'] ), 'Too many blocks in result set' );
+		$this->assertEquals( 1, count( $blocks['blocks'][0]['innerBlocks'] ), 'Too many inner blocks in synced pattern' );
+	}
+
 	/* Multiple nested synced patterns with block bindings -- FINAL BOSS! */
 
 	public function test_multiple_nested_synced_patterns_with_block_bindings() {
@@ -254,6 +521,9 @@ class SyncedPatternsTest extends RegistryTestCase {
 		] );
 
 		$synced_pattern_content_1 = '
+			<!-- wp:group -->
+			<div class=k"wp-block-group">
+
 			<!-- wp:test/custom-block -->
 			<p data-bing="bong">My first synced pattern content</p>
 			<!-- /wp:test/custom-block -->
@@ -265,6 +535,9 @@ class SyncedPatternsTest extends RegistryTestCase {
 			<!-- wp:paragraph {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"my-override"}} -->
 			<p>Default content</p>
 			<!-- /wp:paragraph -->
+
+			</div>
+			<!-- /wp:group -->
 		';
 
 		$synced_pattern_1 = $this->factory()->post->create_and_get( [
@@ -274,6 +547,9 @@ class SyncedPatternsTest extends RegistryTestCase {
 		] );
 
 		$synced_pattern_content_2 = sprintf( '
+			<!-- wp:group -->
+			<div class=k"wp-block-group">
+
 			<!-- wp:test/custom-block -->
 			<p data-bing="bang">My second synced pattern content which contains the first</p>
 			<!-- /wp:test/custom-block -->
@@ -283,6 +559,9 @@ class SyncedPatternsTest extends RegistryTestCase {
 			<!-- wp:test/custom-block -->
 			<p data-bing="bang">Another block to "wrap" the nested pattern</p>
 			<!-- /wp:test/custom-block -->
+
+			</div>
+			<!-- /wp:group -->
 		', $synced_pattern_1->ID );
 
 		$synced_pattern_2 = $this->factory()->post->create_and_get( [
@@ -340,118 +619,9 @@ class SyncedPatternsTest extends RegistryTestCase {
 						],
 						'innerBlocks' => [
 							[
-								'name'       => 'test/custom-block',
-								'attributes' => [
-									'content' => 'My first synced pattern content',
-									'bing'    => 'bong',
-								],
-							],
-							[
-								'name'       => 'core/paragraph',
-								'attributes' => [
-									'content'  => sprintf( 'Block binding for core/paragraph with arg foo=bar in post %d', $post->ID ),
-									'metadata' => [
-										'bindings' => [
-											'content' => [
-												'source' => 'test/synced-pattern-block-binding',
-												'args'   => [ 'foo' => 'bar' ],
-											],
-										],
-									],
-								],
-							],
-							[
-								'name'       => 'core/paragraph',
-								'attributes' => [
-									'content'  => 'Default content',
-									'metadata' => [
-										'bindings' => [
-											'content' => [
-												'source' => 'core/pattern-overrides',
-											],
-										],
-										'name'     => 'my-override',
-									],
-								],
-							],
-						],
-					],
-				],
-			],
-			[
-				'name'        => 'test/custom-container',
-				'attributes'  => [
-					'fizz' => 'buzz',
-				],
-				'innerBlocks' => [
-					[
-						'name'        => 'core/block',
-						'attributes'  => [
-							'ref' => $synced_pattern_1->ID,
-						],
-						'innerBlocks' => [
-							[
-								'name'       => 'test/custom-block',
-								'attributes' => [
-									'content' => 'My first synced pattern content',
-									'bing'    => 'bong',
-								],
-							],
-							[
-								'name'       => 'core/paragraph',
-								'attributes' => [
-									'content'  => sprintf( 'Block binding for core/paragraph with arg foo=bar in post %d', $post->ID ),
-									'metadata' => [
-										'bindings' => [
-											'content' => [
-												'source' => 'test/synced-pattern-block-binding',
-												'args'   => [ 'foo' => 'bar' ],
-											],
-										],
-									],
-								],
-							],
-							[
-								'name'       => 'core/paragraph',
-								'attributes' => [
-									'content'  => 'Overridden content', // Overridden by synced pattern override
-									'metadata' => [
-										'bindings' => [
-											'content' => [
-												'source' => 'core/pattern-overrides',
-											],
-										],
-										'name'     => 'my-override',
-									],
-								],
-							],
-						],
-					],
-				],
-			],
-			[
-				'name'        => 'test/custom-container',
-				'attributes'  => [
-					'fizz' => 'bazz',
-				],
-				'innerBlocks' => [
-					[
-						'name'        => 'core/block',
-						'attributes'  => [
-							'ref' => $synced_pattern_2->ID,
-						],
-						'innerBlocks' => [
-							[
-								'name'       => 'test/custom-block',
-								'attributes' => [
-									'content' => 'My second synced pattern content which contains the first',
-									'bing'    => 'bang',
-								],
-							],
-							[
-								'name'        => 'core/block',
+								'name'        => 'core/group',
 								'attributes'  => [
-									'ref' => $synced_pattern_1->ID,
+									'tagName' => 'div',
 								],
 								'innerBlocks' => [
 									[
@@ -491,11 +661,152 @@ class SyncedPatternsTest extends RegistryTestCase {
 									],
 								],
 							],
+						],
+					],
+				],
+			],
+			[
+				'name'        => 'test/custom-container',
+				'attributes'  => [
+					'fizz' => 'buzz',
+				],
+				'innerBlocks' => [
+					[
+						'name'        => 'core/block',
+						'attributes'  => [
+							'ref' => $synced_pattern_1->ID,
+						],
+						'innerBlocks' => [
 							[
-								'name'       => 'test/custom-block',
-								'attributes' => [
-									'content' => 'Another block to "wrap" the nested pattern',
-									'bing'    => 'bang',
+								'name'        => 'core/group',
+								'attributes'  => [
+									'tagName' => 'div',
+								],
+								'innerBlocks' => [
+									[
+										'name'       => 'test/custom-block',
+										'attributes' => [
+											'content' => 'My first synced pattern content',
+											'bing'    => 'bong',
+										],
+									],
+									[
+										'name'       => 'core/paragraph',
+										'attributes' => [
+											'content'  => sprintf( 'Block binding for core/paragraph with arg foo=bar in post %d', $post->ID ),
+											'metadata' => [
+												'bindings' => [
+													'content' => [
+														'source' => 'test/synced-pattern-block-binding',
+														'args'   => [ 'foo' => 'bar' ],
+													],
+												],
+											],
+										],
+									],
+									[
+										'name'       => 'core/paragraph',
+										'attributes' => [
+											'content'  => 'Overridden content', // Overridden by synced pattern override
+											'metadata' => [
+												'bindings' => [
+													'content' => [
+														'source' => 'core/pattern-overrides',
+													],
+												],
+												'name'     => 'my-override',
+											],
+										],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+			[
+				'name'        => 'test/custom-container',
+				'attributes'  => [
+					'fizz' => 'bazz',
+				],
+				'innerBlocks' => [
+					[
+						'name'        => 'core/block',
+						'attributes'  => [
+							'ref' => $synced_pattern_2->ID,
+						],
+						'innerBlocks' => [
+							[
+								'name'        => 'core/group',
+								'attributes'  => [
+									'tagName' => 'div',
+								],
+								'innerBlocks' => [
+									[
+										'name'       => 'test/custom-block',
+										'attributes' => [
+											'content' => 'My second synced pattern content which contains the first',
+											'bing'    => 'bang',
+										],
+									],
+									[
+										'name'        => 'core/block',
+										'attributes'  => [
+											'ref' => $synced_pattern_1->ID,
+										],
+										'innerBlocks' => [
+											[
+												'name' => 'core/group',
+												'attributes' => [
+													'tagName' => 'div',
+												],
+												'innerBlocks' => [
+													[
+														'name'       => 'test/custom-block',
+														'attributes' => [
+															'content' => 'My first synced pattern content',
+															'bing'    => 'bong',
+														],
+													],
+													[
+														'name'       => 'core/paragraph',
+														'attributes' => [
+															'content'  => sprintf( 'Block binding for core/paragraph with arg foo=bar in post %d', $post->ID ),
+															'metadata' => [
+																'bindings' => [
+																	'content' => [
+																		'source' => 'test/synced-pattern-block-binding',
+																		'args'   => [ 'foo' => 'bar' ],
+																	],
+																],
+															],
+														],
+													],
+													[
+														'name'       => 'core/paragraph',
+														'attributes' => [
+															'content'  => 'Default content',
+															'metadata' => [
+																'bindings' => [
+																	'content' => [
+																		'source' => 'core/pattern-overrides',
+																	],
+																],
+																'name'     => 'my-override',
+															],
+														],
+													],
+												],
+											],
+										],
+									],
+									[
+										'name'       => 'test/custom-block',
+										'attributes' => [
+											'content' => 'Another block to "wrap" the nested pattern',
+											'bing'    => 'bang',
+										],
+									],
 								],
 							],
 						],
@@ -519,15 +830,19 @@ class SyncedPatternsTest extends RegistryTestCase {
 
 		// First synced pattern
 		$this->assertEquals( 1, count( $blocks['blocks'][0]['innerBlocks'] ), 'Too many inner blocks in first container block' );
-		$this->assertEquals( 3, count( $blocks['blocks'][0]['innerBlocks'][0]['innerBlocks'] ), 'Too many inner blocks in first synced pattern' );
+		$this->assertEquals( 1, count( $blocks['blocks'][0]['innerBlocks'][0]['innerBlocks'] ), 'Too many inner blocks in first synced pattern' );
+		$this->assertEquals( 3, count( $blocks['blocks'][0]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'] ), 'Too many inner blocks in first synced pattern group block' );
 
 		// First synced pattern, repeated (contains pattern override)
 		$this->assertEquals( 1, count( $blocks['blocks'][1]['innerBlocks'] ), 'Too many inner blocks in first container block' );
-		$this->assertEquals( 3, count( $blocks['blocks'][1]['innerBlocks'][0]['innerBlocks'] ), 'Too many inner blocks in first synced pattern' );
+		$this->assertEquals( 1, count( $blocks['blocks'][1]['innerBlocks'][0]['innerBlocks'] ), 'Too many inner blocks in first synced pattern' );
+		$this->assertEquals( 3, count( $blocks['blocks'][1]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'] ), 'Too many inner blocks in first synced pattern group block' );
 
 		// Second synced pattern
 		$this->assertEquals( 1, count( $blocks['blocks'][2]['innerBlocks'] ), 'Too many inner blocks in second container block' );
-		$this->assertEquals( 3, count( $blocks['blocks'][2]['innerBlocks'][0]['innerBlocks'] ), 'Too many inner blocks in second synced pattern' );
-		$this->assertEquals( 3, count( $blocks['blocks'][2]['innerBlocks'][0]['innerBlocks'][1]['innerBlocks'] ), 'Too many inner blocks in nested pattern in second synced pattern' );
+		$this->assertEquals( 1, count( $blocks['blocks'][2]['innerBlocks'][0]['innerBlocks'] ), 'Too many inner blocks in second synced pattern' );
+		$this->assertEquals( 3, count( $blocks['blocks'][2]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'] ), 'Too many inner blocks in second synced pattern group block' );
+		$this->assertEquals( 1, count( $blocks['blocks'][2]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'][1]['innerBlocks'] ), 'Too many inner blocks in nested pattern in second synced pattern' );
+		$this->assertEquals( 3, count( $blocks['blocks'][2]['innerBlocks'][0]['innerBlocks'][0]['innerBlocks'][1]['innerBlocks'][0]['innerBlocks'] ), 'Too many inner blocks in nested pattern in second synced pattern group block' );
 	}
 }

--- a/tests/parser/test-synced-patterns.php
+++ b/tests/parser/test-synced-patterns.php
@@ -172,8 +172,8 @@ class SyncedPatternsTest extends RegistryTestCase {
 
 		$expected_blocks = [
 			[
-				'name'        => 'core/block',
-				'attributes'  => [
+				'name'       => 'core/block',
+				'attributes' => [
 					'ref' => -1,
 				],
 				// inner_blocks is omitted when empty for backwards compatibility with earlier release

--- a/tests/parser/test-synced-patterns.php
+++ b/tests/parser/test-synced-patterns.php
@@ -329,7 +329,7 @@ class SyncedPatternsTest extends RegistryTestCase {
 		$this->assertEquals( 1, count( $blocks['blocks'][0]['innerBlocks'] ), 'Too many inner blocks in synced pattern' );
 	}
 
-	/* Synced pattern with sourced attributen nested content */
+	/* Synced pattern with sourced attribute in nested content */
 
 	public function test_synced_pattern_with_sourced_attribute_in_nested_content() {
 		$this->register_block_with_attributes( 'test/custom-block', [
@@ -415,7 +415,7 @@ class SyncedPatternsTest extends RegistryTestCase {
 	public function test_synced_pattern_with_override_in_nested_content() {
 		$synced_pattern_content = '
 			<!-- wp:group -->
-			<div class=k"wp-block-group">
+			<div class="wp-block-group">
 				<!-- wp:group -->
 				<div class="wp-block-group">
 					<!-- wp:paragraph {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"my-override"}} -->
@@ -522,7 +522,7 @@ class SyncedPatternsTest extends RegistryTestCase {
 
 		$synced_pattern_content_1 = '
 			<!-- wp:group -->
-			<div class=k"wp-block-group">
+			<div class="wp-block-group">
 
 			<!-- wp:test/custom-block -->
 			<p data-bing="bong">My first synced pattern content</p>
@@ -548,7 +548,7 @@ class SyncedPatternsTest extends RegistryTestCase {
 
 		$synced_pattern_content_2 = sprintf( '
 			<!-- wp:group -->
-			<div class=k"wp-block-group">
+			<div class="wp-block-group">
 
 			<!-- wp:test/custom-block -->
 			<p data-bing="bang">My second synced pattern content which contains the first</p>

--- a/tests/parser/test-synced-patterns.php
+++ b/tests/parser/test-synced-patterns.php
@@ -165,6 +165,28 @@ class SyncedPatternsTest extends RegistryTestCase {
 		$this->assertEquals( $expected_blocks, $blocks['blocks'], sprintf( 'Blocks not equal: %s', wp_json_encode( $blocks['blocks'] ) ) );
 	}
 
+	/* Missing synced pattern */
+
+	public function test_missing_synced_pattern() {
+		$html = sprintf( '<!-- wp:block {"ref":%d} /-->', -1 );
+
+		$expected_blocks = [
+			[
+				'name'        => 'core/block',
+				'attributes'  => [
+					'ref' => -1,
+				],
+				// inner_blocks is omitted when empty for backwards compatibility with earlier release
+			],
+		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertEquals( $expected_blocks, $blocks['blocks'], sprintf( 'Blocks not equal: %s', wp_json_encode( $blocks['blocks'] ) ) );
+	}
+
 	/* Synced pattern with override */
 
 	public function test_synced_pattern_with_override() {


### PR DESCRIPTION
## Description

Fixes https://github.com/Automattic/vip-block-data-api/issues/86.

Our current solution for extracting and parsing blocks from synced patterns is a bit too experimental. It hooks into the render cycle and attempts to detect when the block being rendered has a synced pattern parent block. It does this via a somewhat fragile inspection of `WP_Block_Supports`.

The issue with that approach is that it can't tell when the synced pattern is a direct parent block vs. an ancestor block, so it ends up duplicating blocks in nested trees. There's no way to make this determination reliably, so we need to abandon that approach. 

Instead of hooking into the existing render cycle, we can just render synced patterns manually. This carries some of its own fragility, because we need to duplicate some code from Core to support synced pattern overrides. But it's an overall improvement and the duplicated code is just a few lines.

It does require making `ContentParser#render_parsed_block` a public method, which was the path I found that required the least refactoring.

@toshotosho Thanks for the failing test case. Can you check out this branch and make sure it resolves the issue for you? Feel free to contribute additional test cases.

