### PR TITLE
Parser: Allow empty content

### DIFF
--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -149,7 +149,9 @@ class ContentParser {
 		// An empty `post_content` fails `has_blocks` check, but is still valid.
 		$content_is_empty = empty( trim( $post_content ) );
 
-		if ( ! ( $content_is_empty || has_blocks( $post_content ) ) ) {
+		$has_content = ! empty( trim( $post_content ) );
+		
+		if ( $has_content && ! has_blocks( $post_content ) ) {
 			$error_message = join(' ', [
 				sprintf( 'Error parsing post ID %d: This post does not appear to contain block content.', $post_id ),
 				'The VIP Block Data API is designed to parse Gutenberg blocks and can not read classic editor content.',

--- a/src/parser/content-parser.php
+++ b/src/parser/content-parser.php
@@ -146,9 +146,10 @@ class ContentParser {
 
 		$this->warnings = [];
 
-		$has_blocks = has_blocks( $post_content );
+		// An empty `post_content` fails `has_blocks` check, but is still valid.
+		$content_is_empty = empty( trim( $post_content ) );
 
-		if ( ! $has_blocks ) {
+		if ( ! ( $content_is_empty || has_blocks( $post_content ) ) ) {
 			$error_message = join(' ', [
 				sprintf( 'Error parsing post ID %d: This post does not appear to contain block content.', $post_id ),
 				'The VIP Block Data API is designed to parse Gutenberg blocks and can not read classic editor content.',

--- a/tests/parser/test-content-parser.php
+++ b/tests/parser/test-content-parser.php
@@ -7,6 +7,8 @@
 
 namespace WPCOMVIP\BlockDataApi;
 
+use WP_Error;
+
 /**
  * Content parser tests that are not source-specific.
  */
@@ -208,6 +210,38 @@ class ContentParserTest extends RegistryTestCase {
 				],
 			],
 		];
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertEquals( $expected_blocks, $blocks['blocks'], sprintf( 'Blocks do not match: %s', wp_json_encode( $blocks ) ) );
+	}
+
+	/* Classic editor content */
+
+	public function test_parse_classic_editor_content() {
+		$html = 'Hello, world!';
+
+		$content_parser = new ContentParser( $this->get_block_registry() );
+		$blocks         = $content_parser->parse( $html );
+
+		$this->assertInstanceOf( WP_Error::class, $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+
+		$errors = $blocks->get_error_messages();
+		$this->assertEquals( 1, count( $errors ), 'Expected error messages but found none.' );
+		$this->assertStringContainsString(
+			'This post does not appear to contain block content.',
+			$errors[0],
+			sprintf( 'Unexpected error messages: %s', wp_json_encode( $errors ) )
+		);
+	}
+
+	/* Empty content */
+
+	public function test_parse_empty_content() {
+		$html            = '';
+		$expected_blocks = [];
 
 		$content_parser = new ContentParser( $this->get_block_registry() );
 		$blocks         = $content_parser->parse( $html );


### PR DESCRIPTION
## Description

Empty content fails the `has_blocks` check, but is valid block markup. Fixes #92 

## Steps to Test

Covered by new unit tests.