### PR TITLE
Add release workflow automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - trunk
 
+permissions:
+  contents: write
+
 jobs:
   check_and_release:
     runs-on: ubuntu-latest
@@ -23,6 +26,7 @@ jobs:
             echo "Error: Version mismatch detected!"
             echo "Plugin header version: $NEW_VERSION"
             echo "Defined constant version: $DEFINED_VERSION"
+            exit 1
           fi
 
           if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
             echo "Error: Version mismatch detected!"
             echo "Plugin header version: $NEW_VERSION"
             echo "Defined constant version: $DEFINED_VERSION"
+            exit 1
           fi
 
           if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+on:
+  push:
+    branches:
+      - trunk
+
+jobs:
+  check_and_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for version change
+        id: version_check
+        run: |
+          OLD_VERSION=$(git show HEAD^:vip-block-data-api.php | sed -n 's/.*Version: *//p' | tr -d '[:space:]')
+          NEW_VERSION=$(git show HEAD:vip-block-data-api.php | sed -n 's/.*Version: *//p' | tr -d '[:space:]')
+          DEFINED_VERSION=$(git show HEAD:vip-block-data-api.php | sed -n "s/.*define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '\\([^']*\\)'.*/\\1/p")
+
+          if [ "$NEW_VERSION" != "$DEFINED_VERSION" ]; then
+            echo "Error: Version mismatch detected!"
+            echo "Plugin header version: $NEW_VERSION"
+            echo "Defined constant version: $DEFINED_VERSION"
+          fi
+
+          if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+            echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            echo "Version changed from $OLD_VERSION to $NEW_VERSION"
+          else
+            echo "No version change detected"
+          fi
+
+      - name: Build plugin zip
+        if: steps.version_check.outputs.new_version
+        run: |
+          VERSION="${{ steps.version_check.outputs.new_version }}"
+          git archive --prefix "vip-block-data-api/" HEAD -o "vip-block-data-api-${VERSION}.zip"
+
+      - name: Create Release
+        if: steps.version_check.outputs.new_version
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version_check.outputs.new_version }}
+          files: vip-block-data-api-${{ steps.version_check.outputs.new_version }}.zip
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
             echo "Error: Version mismatch detected!"
             echo "Plugin header version: $NEW_VERSION"
             echo "Defined constant version: $DEFINED_VERSION"
-            exit 1
           fi
 
           if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,61 +1,15 @@
 # Release steps
 
-## 1. Create a release branch
+## 1. Bump plugin version
 
-1. Before merging a feature, create a release branch for the next target version, e.g.
+1. When the version is ready for release, bump the version number in `vip-block-data-api.php`. Change plugin header and `WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION` to match new version.
+2. PR version changes and merge to `trunk`. On version change, the release workflow will generate a new tag and release ZIP.
 
-    ```bash
-    git checkout trunk
-    git checkout -b planned-release/0.2.1
-    ```
-
-2. In GitHub, select the base branch as the `planned-release/...` branch.
-3. Merge feature branches into the `planned-release/...` branch.
-
-## 2. Bump plugin version
-
-1. When the version is ready for release, inside the `planned-release/...` branch, bump the version number in `vip-block-data-api.php`. Change plugin header and `WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION` to match new version.
-2. Push the `planned-release/...` branch to GitHub.
-3. PR version changes with feature changes and merge to `trunk`.
-
-## 3. Tag branch for release
-
-1. In `trunk`, add a signed tag for the release:
-
-    ```bash
-    git checkout trunk
-    git pull
-    git tag -s -a <version> -m "Release <version>"
-
-    # e.g. git tag -s -a 1.0.2 -m "Release 1.0.2"
-    ```
-
-2. Run `git push --tags`.
-
-## 4. Create a release
-
-1. In the `vip-block-data-api` folder, run this command to create a plugin ZIP:
-
-    ```bash
-    git archive --prefix "vip-block-data-api/" <version> -o vip-block-data-api-<version>.zip
-
-    # e.g. git archive --prefix "vip-block-data-api/" 1.0.2 -o vip-block-data-api-1.0.2.zip
-    #
-    # Creates a ZIP archive with the prefix folder "vip-block-data-api/" containing files from tag 1.0.2
-    ```
-
-2. Visit the [vip-block-data-api create release page](https://github.com/Automattic/vip-block-data-api/releases/new).
-3. Select the newly created version tag in the dropdown.
-4. For the title, enter the release version name (e.g. `1.0.2`)
-5. Add a description of release changes.
-6. Attach the plugin ZIP.
-7. Click "Publish release."
-
-## 5. Update integrations
+## 2. Update integrations
 
 Patch updates (e.g. `1.2.3` -> `1.2.4`) do not require any additional steps.
 
-This section applies if the plugin has increased by a minor (e.g. `1.2` -> `1.3`) or major (e.g. `1.2` -> `2.0`) version. 
+This section applies if the plugin has increased by a minor (e.g. `1.2` -> `1.3`) or major (e.g. `1.2` -> `2.0`) version.
 
 For an example updating an integration version, [see this mu-plugins PR](https://github.com/Automattic/vip-go-mu-plugins/pull/5409).
 


### PR DESCRIPTION
## Description

See https://github.com/Automattic/vip-block-data-api/issues/47. Recreate the steps in [RELEASE.md](https://github.com/Automattic/vip-block-data-api/blob/ddc91c93d7d316fe9255693da60da38761651a96/RELEASE.md) in a GitHub workflow. After this is merged, we should be able to update the plugin version on `trunk` and the tag/zip should be auto-created with release notes.

