### PR TITLE
Fix/release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,6 @@ jobs:
         if: steps.version_check.outputs.new_version
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version_check.outputs.new_version }}
+          tag_name: ${{ steps.version_check.outputs.new_version }}
           files: vip-block-data-api-${{ steps.version_check.outputs.new_version }}.zip
           generate_release_notes: true

--- a/vip-block-data-api.php
+++ b/vip-block-data-api.php
@@ -5,7 +5,7 @@
  * Description: Access Gutenberg block data in JSON via the REST API.
  * Author: WordPress VIP
  * Text Domain: vip-block-data-api
- * Version: 1.4.6
+ * Version: 1.4.7
  * Requires at least: 6.0
  * Tested up to: 6.8
  * Requires PHP: 8.1
@@ -33,7 +33,7 @@ if ( ! defined( 'VIP_BLOCK_DATA_API_LOADED' ) ) {
 		return;
 	}
 
-	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '1.4.6' );
+	define( 'WPCOMVIP__BLOCK_DATA_API__PLUGIN_VERSION', '1.4.7' );
 	define( 'WPCOMVIP__BLOCK_DATA_API__REST_ROUTE', 'vip-block-data-api/v1' );
 
 	// Analytics related configs.


### PR DESCRIPTION
## Description

Fixes release automation workflow in https://github.com/Automattic/vip-block-data-api/pull/94 which after adding a `v` prefix, [wasn't properly pulled into the integration center](https://github.com/Automattic/vip-go-mu-plugins-ext/pull/99).

This PR also bumps the version to `1.4.7` to test that future releases will work without issue.

