### PR TITLE
fix: allow null block names in core block filter

### DIFF
--- a/src/parser/block-additions/core-block.php
+++ b/src/parser/block-additions/core-block.php
@@ -58,12 +58,12 @@ class CoreBlock {
 	 * https://github.com/WordPress/WordPress/blob/6.6.1/wp-includes/blocks/block.php#L19
 	 *
 	 * @param array    $inner_blocks Inner blocks.
-	 * @param string   $block_name   Block name.
+	 * @param string|null $block_name   Block name, or null for parsed non-block content.
 	 * @param int|null $post_id      Post ID.
 	 * @param array    $parsed_block Parsed block data.
 	 * @return array
 	 */
-	public static function get_inner_blocks( array $inner_blocks, string $block_name, int|null $post_id, array $parsed_block ): array {
+	public static function get_inner_blocks( array $inner_blocks, string|null $block_name, int|null $post_id, array $parsed_block ): array {
 		// Not a synced pattern? Return the inner blocks unchanged.
 		if ( self::$block_name !== $block_name || ! isset( $parsed_block['attrs']['ref'] ) ) {
 			return $inner_blocks;

--- a/tests/parser/test-inner-blocks.php
+++ b/tests/parser/test-inner-blocks.php
@@ -186,4 +186,17 @@ class InnerBlocksTest extends RegistryTestCase {
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
 		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
 	}
+	public function test_core_block_inner_blocks_filter_ignores_null_block_names() {
+		$inner_blocks = [ 'existing-inner-block' ];
+
+		$result = \WPCOMVIP\BlockDataApi\ContentParser\BlockAdditions\CoreBlock::get_inner_blocks(
+			$inner_blocks,
+			null,
+			1,
+			[ 'blockName' => null ]
+		);
+
+		$this->assertSame( $inner_blocks, $result );
+	}
+
 }


### PR DESCRIPTION
Fixes #99.

This updates the synced-pattern inner-block filter to accept the null block names that WordPress can pass for parsed non-block/classic-content fragments. In that case the filter now returns the existing inner blocks unchanged instead of raising a PHP TypeError before the parser can continue.

I also added a focused regression test that calls the filter with a null block name.

Verification: I could not run the WordPress/PHP test suite in this cron profile because php/composer/git are not installed here. I did a static patch check against the current trunk file contents via the GitHub API.