### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           tools: composer
           php-version: ${{ matrix.php-versions }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -38,13 +38,13 @@ jobs:
         run: npm -g install @wordpress/env
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php }}
           tools: composer
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # 3.2.1
         with:
           composer-options: --prefer-dist --no-progress
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Create Release
         if: steps.version_check.outputs.new_version
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.version_check.outputs.new_version }}
           files: vip-block-data-api-${{ steps.version_check.outputs.new_version }}.zip


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 3
- Repo-level unpinned usage count from the trunk recheck: 4
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)


Verification commands:

```bash
# ramsey/composer-install # 3.2.1 -> a8d0d959dab41457692a5e2041bd9b757a119e3f
gh api repos/ramsey/composer-install/commits/3.2.1 --jq '.sha'
# expected: a8d0d959dab41457692a5e2041bd9b757a119e3f

# shivammathur/setup-php # 2.37.1 -> 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
gh api repos/shivammathur/setup-php/commits/2.37.1 --jq '.sha'
# expected: 7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc

# softprops/action-gh-release # v2.6.2 -> 3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
gh api repos/softprops/action-gh-release/commits/v2.6.2 --jq '.sha'
# expected: 3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
```
