### PR TITLE
Support resized image dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1357,7 +1357,7 @@ function add_custom_block_metadata( $sourced_block, $block_name, $post_id, $bloc
 
 Direct block HTML can be accessed through `$block['innerHTML']`. This may be useful if manual HTML parsing is necessary to gather data from a block.
 
-For another example of how this filter can be used to extend block data, we have implemented a default image block filter in [`src/parser/block-additions/core-image.php`][repo-core-image-block-addition]. This filter is automatically called on `core/image` blocks to add `width` and `height` to image attributes.
+For another example of how this filter can be used to extend block data, we have implemented a default image block filter in [`src/parser/block-additions/core-image.php`][repo-core-image-block-addition]. This filter is automatically called on `core/image` blocks to add `width` and `height` to image attributes. When an image has been resized in the editor (e.g. via the drag handles), the editor-selected dimensions are also exposed as `resize-width` and `resize-height`, while `width` and `height` continue to reflect the attachment's full-size dimensions.
 
 ---
 

--- a/src/parser/block-additions/core-image.php
+++ b/src/parser/block-additions/core-image.php
@@ -66,6 +66,18 @@ class CoreImage {
 	private static function get_size_metadata( $attributes, $attachment_metadata ) {
 		$size_metadata = [];
 
+		// Preserve any editor-provided dimensions (e.g. from drag-to-resize) as
+		// separate resize-width/resize-height attributes. The width/height
+		// attributes below are overwritten with the attachment's metadata, which
+		// would otherwise discard the resized dimensions selected in the editor.
+		if ( isset( $attributes['width'] ) ) {
+			$size_metadata['resize-width'] = $attributes['width'];
+		}
+
+		if ( isset( $attributes['height'] ) ) {
+			$size_metadata['resize-height'] = $attributes['height'];
+		}
+
 		if ( isset( $attachment_metadata['width'] ) ) {
 			$size_metadata['width'] = $attachment_metadata['width'];
 		}

--- a/tests/parser/blocks/test-image-block.php
+++ b/tests/parser/blocks/test-image-block.php
@@ -42,6 +42,39 @@ class ImageBlockTest extends WP_UnitTestCase {
 		$content_parser = new ContentParser();
 		$blocks         = $content_parser->parse( $html );
 		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
-		$this->assertArraySubset( $expected_blocks, $expected_blocks, true );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
+	}
+
+	public function test_parse_core_image_resized_keeps_metadata_and_resize_attributes() {
+		$attachment_id  = $this->factory()->attachment->create_upload_object( WPCOMVIP__BLOCK_DATA_API__TEST_DATA . '/blue.png' );
+		$attachment_url = wp_get_attachment_url( $attachment_id );
+
+		// A drag-to-resize in the editor stores width/height in the block attributes.
+		$html = '
+			<!-- wp:image {"id":' . $attachment_id . ',"width":"300px","height":"169px"} -->
+			<figure class="wp-block-image">
+				<img src="' . $attachment_url . '" />
+			</figure>
+			<!-- /wp:image -->
+		';
+
+		$expected_blocks = [
+			[
+				'name'       => 'core/image',
+				'attributes' => [
+					// Full-size dimensions from the attachment metadata are preserved.
+					'width'         => 800,
+					'height'        => 450,
+					// Editor-selected resize dimensions are exposed separately.
+					'resize-width'  => '300px',
+					'resize-height' => '169px',
+				],
+			],
+		];
+
+		$content_parser = new ContentParser();
+		$blocks         = $content_parser->parse( $html );
+		$this->assertArrayHasKey( 'blocks', $blocks, sprintf( 'Unexpected parser output: %s', wp_json_encode( $blocks ) ) );
+		$this->assertArraySubset( $expected_blocks, $blocks['blocks'], true );
 	}
 }

--- a/tests/parser/blocks/test-image-block.php
+++ b/tests/parser/blocks/test-image-block.php
@@ -46,12 +46,38 @@ class ImageBlockTest extends WP_UnitTestCase {
 	}
 
 	public function test_parse_core_image_resized_keeps_metadata_and_resize_attributes() {
+		global $wp_version;
+
+		// A drag-to-resize in the editor stores width/height in the block
+		// attributes. The type of these attributes changed in WordPress 6.3
+		// from numbers (e.g. 300) to unit strings (e.g. "300px").
+		// Test each shape against the version that produces it.
+		if ( version_compare( $wp_version, '6.3', '<' ) ) {
+			$this->assert_resize_attributes_preserved( 300, 169 );
+		} else {
+			$this->assert_resize_attributes_preserved( '300px', '169px' );
+		}
+	}
+
+	/**
+	 * Assert that a resized core/image keeps its full-size metadata dimensions
+	 * as width/height while exposing the editor resize dimensions separately.
+	 *
+	 * @param int|string $resize_width  Editor-selected width stored in the block attributes.
+	 * @param int|string $resize_height Editor-selected height stored in the block attributes.
+	 */
+	private function assert_resize_attributes_preserved( $resize_width, $resize_height ) {
 		$attachment_id  = $this->factory()->attachment->create_upload_object( WPCOMVIP__BLOCK_DATA_API__TEST_DATA . '/blue.png' );
 		$attachment_url = wp_get_attachment_url( $attachment_id );
 
-		// A drag-to-resize in the editor stores width/height in the block attributes.
+		$image_attributes = [
+			'id'     => $attachment_id,
+			'width'  => $resize_width,
+			'height' => $resize_height,
+		];
+
 		$html = '
-			<!-- wp:image {"id":' . $attachment_id . ',"width":"300px","height":"169px"} -->
+			<!-- wp:image ' . wp_json_encode( $image_attributes ) . ' -->
 			<figure class="wp-block-image">
 				<img src="' . $attachment_url . '" />
 			</figure>
@@ -66,8 +92,8 @@ class ImageBlockTest extends WP_UnitTestCase {
 					'width'         => 800,
 					'height'        => 450,
 					// Editor-selected resize dimensions are exposed separately.
-					'resize-width'  => '300px',
-					'resize-height' => '169px',
+					'resize-width'  => $resize_width,
+					'resize-height' => $resize_height,
 				],
 			],
 		];


### PR DESCRIPTION
## Description

Closes https://github.com/Automattic/vip-block-data-api/issues/106.

Previously, resized dimensions were overwritten by `src/parser/block-additions/core-image.php`'s added `width` and `height` dimensions. For example:

<img width="1158" height="740" alt="resized-image" src="https://github.com/user-attachments/assets/7fe27ce7-f9fc-405e-b810-71dc99adc24a" />

This post contains two images, one original and one resized. The HTML reflects this:

```html
<!-- wp:image {"id":8,"sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large"><img src="http://localhost:8888/wp-content/uploads/2026/07/sotw-2024-1-1024x683.png" alt="" class="wp-image-8"/></figure>
<!-- /wp:image -->~

<!-- ... ->

<!-- wp:image {"id":9,"width":"212px","height":"auto","aspectRatio":"1.4992445383313449","sizeSlug":"large","linkDestination":"none"} -->
<figure class="wp-block-image size-large is-resized"><img src="http://localhost:8888/wp-content/uploads/2026/07/sotw-2024-1-1-1024x683.png" alt="" class="wp-image-9" style="aspect-ratio:1.4992445383313449;width:212px;height:auto"/></figure>
<!-- /wp:image -->
```

The first image has no manual `width` or `height` set, but the second image has `width":"212px", "height":"auto"` set in the block delimiter. Although these are different, when rendered through the block data API, the results are largely the same:

```js
{
    "name": "core/image",
    "attributes": {
        "alt": "",
        "id": 8,
        "linkDestination": "none",
        "sizeSlug": "large",
        "url": "...",
        "width": 1024,
        "height": 683
    }
},
/* ... */
{
    "name": "core\/image",
    "attributes": {
        "alt": "",
        "aspectRatio": "1.4992445383313449",
        "id": 9,
        "linkDestination": "none",
        "sizeSlug": "large",
        "url": "...",
        "width": 1024,
        "height": 683
    }
}
```

That's because the delimiter-defined `width` and `height` are overwritten by the image block addition. Following @codedbyglenden's idea, the fix in this PR preserves the attribute-set width and height in `resize-width` and `resize-height` attributes:

```js
{
    "name": "core/image",
    "attributes": {
        "alt": "",
        "id": 8,
        "linkDestination": "none",
        "sizeSlug": "large",
        "url": "http:/localhost:8888/wp-content/uploads/2026/07/sotw-2024-1-1024x683.png",
        "width": 1024,
        "height": 683
    }
},
/* ... */
{
    "name": "core/image",
    "attributes": {
        "alt": "",
        "aspectRatio": "1.4992445383313449",
        "id": 9,
        "linkDestination": "none",
        "sizeSlug": "large",
        "url": "http:/localhost:8888/wp-content/uploads/2026/07/sotw-2024-1-1-1024x683.png",
        "width": 1024,
        "height": 683,
        "resize-width": "212px",
        "resize-height": "auto"
    }
}
```

`width` and `height` still show the native image attachment version for backwards compatibility. Also, the delimiter-sourced attributes are strings (`"212px"`, `"auto"`) instead of numbers, so a separate attribute feels like the safer path.